### PR TITLE
Rename to govuk-dependabot-merger

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GitHub Action: Dependabot Automerge
+# GOV.UK Dependabot Merger
 
 > This repository is a **Work In Progress** and should not be used in production.
 
@@ -23,7 +23,7 @@ With that ENV variable created, you can trigger the auto-merge script with:
 bundle exec ruby bin/merge_dependabot_prs.rb
 ```
 
-> The long term aim is to store this token as a repository secret in github-action-dependabot-auto-merge, and trigger the above script on a GitHub Action crob/schedule.
+> The long term aim is to store this token as a repository secret in govuk-dependabot-merger, and trigger the above script on a GitHub Action crob/schedule.
 > Note also that current token is linked to 'chrisbashton' and has permissions against the 'chris-test-repo' only. It will eventually be replaced with a token linked to 'govuk-ci', and with permission against more repositories.
 
 ### Running the test suite

--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -72,7 +72,7 @@ class PullRequest
 
   def approve!
     approval_message = <<~REVIEW_COMMENT
-      This PR has been scanned and automatically approved by [github-action-dependabot-auto-merge](https://github.com/alphagov/github-action-dependabot-auto-merge).
+      This PR has been scanned and automatically approved by [govuk-dependabot-merger](https://github.com/alphagov/govuk-dependabot-merger).
     REVIEW_COMMENT
     response = HTTParty.post(
       "https://api.github.com/repos/alphagov/#{@api_response.base.repo.name}/pulls/#{@api_response.number}/reviews",

--- a/spec/lib/pull_request_spec.rb
+++ b/spec/lib/pull_request_spec.rb
@@ -280,7 +280,7 @@ RSpec.describe PullRequest do
       stub_request(:post, approval_api_url).with(
         body: {
           "event": "APPROVE",
-          "body": "This PR has been scanned and automatically approved by [github-action-dependabot-auto-merge](https://github.com/alphagov/github-action-dependabot-auto-merge).\n",
+          "body": "This PR has been scanned and automatically approved by [govuk-dependabot-merger](https://github.com/alphagov/govuk-dependabot-merger).\n",
         }.to_json,
       ).to_return(status: 200)
 


### PR DESCRIPTION
Previous name: github-action-dependabot-auto-merge. It was named when we were still considering whether it should be built as a reusable GitHub Action workflow and triggered externally from GOV.UK PRs. The 'github-action' prefix would be appropriate for that scenario.

However, this repo will now run on a schedule. It uses GitHub Actions to drive that, but could just as easily be invoked from a different tool, such as Jenkins. The 'github-action' prefix now exposes an implementation detail that shouldn't really be a part of the service name.

Removing the prefix leaves us with 'dependabot-auto-merge', but the 'auto' is implied (we're programmers, after all, seeking to automate things). 'merge' is a verb, which doesn't describe the service as well as a noun would ('merger'). Finally, a 'govuk' prefix helps indicate that this is very much intended for a GOV.UK engineer audience, as the repo makes several assumptions about the safety of auto-merging Dependabot PRs based on GOV.UK standards such as high test coverage (see RFC-156).

Trello: https://trello.com/c/RblylctX/3136-build-the-auto-merge-service-for-dependabot-prs-5