### PR TITLE
Run Dependabot merger Mon-Fri at 10:30am

### DIFF
--- a/.github/workflows/merge-dependabot-prs.yml
+++ b/.github/workflows/merge-dependabot-prs.yml
@@ -1,0 +1,25 @@
+name: "Merge Dependabot PRs"
+
+on:
+  schedule:
+    # 10:30am, Mon-Fri. There is also logic within the script to prevent running on bank holidays.
+    - cron: '30 10 * * 1-5'
+  workflow_dispatch: {}
+
+jobs:
+  review-users:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Run Dependabot-merger script
+        env:
+          AUTO_MERGE_TOKEN: ${{ secrets.AUTO_MERGE_TOKEN }}
+        run: |
+          bundle exec ruby bin/merge_dependabot_prs.rb


### PR DESCRIPTION
There is also logic in the merger script to prevent running on bank holidays (see https://github.com/alphagov/govuk-dependabot-merger/pull/2).

10:30am was decided as a good time to run, on the basis that 2nd line starts at 9:30am. Note that the original RFC proposed that we also configure Dependabot to only raise PRs at 9:30am, to avoid auto-merging out-of-hours. However, that was on the basis of a push mechanism (Dependabot PR raised -> Auto merger service called). We've opted for a pull mechanism (daily time of 10:30am to pull all Dependabot PRs and auto-merge if appropriate). Therefore it doesn't matter what time a Dependabot PR is opened, it will still only be merged at 10:30am.

See https://github.com/alphagov/govuk-rfcs/blob/main/rfc-156-auto-merge-internal-prs.md#5-during-office-hours

Trello: https://trello.com/c/RblylctX/3136-build-the-auto-merge-service-for-dependabot-prs-5