### PR TITLE
Opt-in govuk-developer-docs to the govuk-dependabot-merger service

### DIFF
--- a/config/repos_opted_in.yml
+++ b/config/repos_opted_in.yml
@@ -1,1 +1,1 @@
-- test-repo-chris
+- govuk-developer-docs


### PR DESCRIPTION
This repo is currently the only one with a valid
[.govuk_dependabot_merger.yml](https://github.com/alphagov/govuk-developer-docs/blob/9b6b8ef39d465b8acc2251d0ad242e0270d85c2e/.govuk_dependabot_merger.yml) file. We'll monitor how well the auto-merger service works over the next few weeks before publicising the service more widely.

Trello: https://trello.com/c/Zlea7Wce/3259-trial-auto-merge-service-for-one-repo