### PR TITLE
Rename the job at merge-dependabot-prs.yml

### DIFF
--- a/.github/workflows/merge-dependabot-prs.yml
+++ b/.github/workflows/merge-dependabot-prs.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch: {}
 
 jobs:
-  review-users:
+  merge-dependabot-prs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
This action was originally copied from govuk-user-reviewer, so the "review-users" job name is an artefact from that time. Renaming to something more appropriate.