### PR TITLE
Check only for changes mentioned in the commit message

### DIFF
--- a/spec/lib/pull_request_spec.rb
+++ b/spec/lib/pull_request_spec.rb
@@ -4,6 +4,61 @@ require_relative "../../lib/pull_request"
 RSpec.describe PullRequest do
   before { set_up_mock_token }
 
+  def single_dependency_commit
+    <<~TEXT
+      Bump govuk_publishing_components from 35.7.0 to 35.8.0
+
+      Bumps [govuk_publishing_components](https://github.com/alphagov/govuk_publishing_components) from 35.7.0 to 35.8.0.
+      - [Changelog](https://github.com/alphagov/govuk_publishing_components/blob/main/CHANGELOG.md)
+      - [Commits](alphagov/govuk_publishing_components@v35.7.0...v35.8.0)
+
+      ---
+      updated-dependencies:
+      - dependency-name: govuk_publishing_components
+        dependency-type: direct:production
+        update-type: version-update:semver-minor
+      ...
+
+      Signed-off-by: dependabot[bot] <support@github.com>
+    TEXT
+  end
+
+  def multiple_dependencies_commit
+    <<~TEXT
+      Bump rack, rails and govuk_sidekiq
+
+      Bumps [rack](https://github.com/rack/rack), [rails](https://github.com/rails/rails) and [govuk_sidekiq](https://github.com/alphagov/govuk_sidekiq). These dependencies needed to be updated together.
+
+      Updates `rack` from 1.0.0 to 1.1.0
+      - [Release notes](https://github.com/rack/rack/releases)
+      - [Changelog](https://github.com/rack/rack/blob/main/CHANGELOG.md)
+      - [Commits](rack/rack@v1.0.0...v1.1.0)
+
+      Updates `rails` from 7.0.8 to 7.1.1
+      - [Release notes](https://github.com/rails/rails/releases)
+      - [Commits](rails/rails@v7.0.8...v7.1.1)
+
+      Updates `govuk_sidekiq` from 5.7.0 to 5.8.0
+      - [Changelog](https://github.com/alphagov/govuk_sidekiq/blob/main/CHANGELOG.md)
+      - [Commits](alphagov/govuk_sidekiq@v5.7.0...v5.8.0)
+
+      ---
+      updated-dependencies:
+      - dependency-name: rack
+        dependency-type: direct:development
+        update-type: version-update:semver-minor
+      - dependency-name: rails
+        dependency-type: direct:production
+        update-type: version-update:semver-minor
+      - dependency-name: govuk_sidekiq
+        dependency-type: direct:production
+        update-type: version-update:semver-minor
+      ...
+
+      Signed-off-by: dependabot[bot] <support@github.com>
+    TEXT
+  end
+
   let(:repo_name) { "foo" }
   let(:sha) { "ee241dea8da11aff8e575941c138a7f34ddb1a51" }
   let(:pull_request_api_response) do
@@ -40,6 +95,7 @@ RSpec.describe PullRequest do
         author: {
           name: "dependabot[bot]",
         },
+        message: single_dependency_commit,
       },
       author: {
         login: "dependabot[bot]",
@@ -318,6 +374,7 @@ RSpec.describe PullRequest do
       dependency_manager = double("DependencyManager")
       api_response = "foo"
       pull_request = PullRequest.new(api_response, dependency_manager)
+      allow(pull_request).to receive(:commit_message).and_return(single_dependency_commit)
       allow(pull_request).to receive(:gemfile_lock_changes).and_return(
         <<~GEMFILE_LOCK_DIFF,
           govuk_personalisation (0.13.0)
@@ -337,6 +394,61 @@ RSpec.describe PullRequest do
       expect(dependency_manager).to receive(:add_dependency).with(
         name: "govuk_publishing_components",
         version: "35.8.0",
+      )
+      pull_request.tell_dependency_manager_what_dependabot_is_changing
+    end
+
+    it "only looks at the dependencies listed in the commit message" do
+      dependency_manager = double("DependencyManager")
+      api_response = "foo"
+      pull_request = PullRequest.new(api_response, dependency_manager)
+      allow(pull_request).to receive(:commit_message).and_return(multiple_dependencies_commit)
+      allow(pull_request).to receive(:gemfile_lock_changes).and_return(
+        <<~GEMFILE_LOCK_DIFF,
+          govuk_personalisation (0.13.0)
+                  plek (>= 1.9.0)
+                  rails (>= 6, < 8)
+          -    govuk_publishing_components (35.7.0)
+          +    govuk_publishing_components (35.8.0)
+                  govuk_app_config
+                  govuk_personalisation (>= 0.7.0)
+                  kramdown
+          -    rack (1.0.0)
+          +    rack (1.1.0)
+          -    rails (7.0.8)
+          +    rails (7.1.1)
+          -    govuk_sidekiq (5.7.0)
+          +    govuk_sidekiq (5.8.0)
+        GEMFILE_LOCK_DIFF
+      )
+
+      expect(dependency_manager).to receive(:add_dependency).with(
+        name: "rack",
+        version: "1.1.0",
+      )
+      expect(dependency_manager).to receive(:add_dependency).with(
+        name: "rails",
+        version: "7.1.1",
+      )
+      expect(dependency_manager).to receive(:add_dependency).with(
+        name: "govuk_sidekiq",
+        version: "5.8.0",
+      )
+      expect(dependency_manager).to receive(:remove_dependency).with(
+        name: "rack",
+        version: "1.0.0",
+      )
+      expect(dependency_manager).to receive(:remove_dependency).with(
+        name: "rails",
+        version: "7.0.8",
+      )
+      expect(dependency_manager).not_to receive(:add_dependency).with(
+        name: "govuk_publishing_components",
+        version: "35.8.0",
+      )
+      expect(dependency_manager).not_to receive(:remove_dependency).with(
+        name: "govuk_publishing_components",
+        version: "35.7.0",
       )
       pull_request.tell_dependency_manager_what_dependabot_is_changing
     end


### PR DESCRIPTION
Only check the gemfile.lock for changes that have been mentioned in the commit message. This is because we want to ignore sub-dependencies.

https://trello.com/c/c2KqD9Fu/3328-review-effectiveness-of-version-1-of-the-govuk-dependabot-merger