### PR TITLE
Change test name string

### DIFF
--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -61,7 +61,7 @@ class PullRequest
     # so we need to make the API call manually.
     uri = "https://api.github.com/repos/alphagov/#{@api_response.base.repo.name}/commits/#{@api_response.head.sha}/check-runs"
     check_runs = HTTParty.get(uri)["check_runs"]
-    return false unless check_runs && (ci_run = check_runs.find { |run| run["name"] == "test" })
+    return false unless check_runs && (ci_run = check_runs.find { |run| run["name"] == "Test Ruby" })
 
     ci_run["conclusion"] == "success"
   end

--- a/spec/lib/pull_request_spec.rb
+++ b/spec/lib/pull_request_spec.rb
@@ -471,7 +471,7 @@ RSpec.describe PullRequest do
 
   def stub_successful_check_run
     stub_check_run({
-      name: "test",
+      name: "Test Ruby",
       status: "completed",
       conclusion: "success",
     })


### PR DESCRIPTION
We've noticed that almost all our apps have the CI tests name key set as "Test Ruby", so to avoid changing this everywhere else we're amending the auto-merger and the few repos that might need it.

https://trello.com/c/0oXuuZjE/3358-fix-govuk-dependabot-merger-2