### PR TITLE
Catch exceptions when merging pull requests

### DIFF
--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -93,6 +93,8 @@ class PullRequest
 
   def merge!
     GitHubClient.instance.merge_pull_request("alphagov/#{@api_response.base.repo.name}", @api_response.number)
+  rescue Octokit::Error => e
+    puts "Error merging pull request: #{e.message}"
   end
 
   def head_commit


### PR DESCRIPTION
We're not handling exceptions and it's polluting the logs: https://github.com/alphagov/govuk-dependabot-merger/actions/runs/6955353884/job/18923957591

https://trello.com/c/0oXuuZjE/3358-fix-govuk-dependabot-merger-2