### PR TITLE
Fix potential RCE in dependency_manager.

### DIFF
--- a/lib/dependency_manager.rb
+++ b/lib/dependency_manager.rb
@@ -81,7 +81,7 @@ class DependencyManager
   def all_proposed_dependencies_are_internal?
     proposed_dependency_updates.each do |proposed_update|
       uri = "https://rubygems.org/api/v1/gems/#{proposed_update[:name]}/owners.yaml"
-      gem_owners = YAML.load(HTTParty.get(uri))
+      gem_owners = YAML.safe_load(HTTParty.get(uri))
       return false unless gem_owners.map { |owner| owner["handle"] }.include?("govuk")
     end
 

--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -110,7 +110,7 @@ class PullRequest
   end
 
   def remote_config
-    @remote_config ||= YAML.load(GitHubClient.instance.contents(
+    @remote_config ||= YAML.safe_load(GitHubClient.instance.contents(
                                    "alphagov/#{@api_response.base.repo.name}",
                                    {
                                      accept: "application/vnd.github.raw",

--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -111,12 +111,12 @@ class PullRequest
 
   def remote_config
     @remote_config ||= YAML.safe_load(GitHubClient.instance.contents(
-                                   "alphagov/#{@api_response.base.repo.name}",
-                                   {
-                                     accept: "application/vnd.github.raw",
-                                     path: ".govuk_dependabot_merger.yml",
-                                   },
-                                 ))
+                                        "alphagov/#{@api_response.base.repo.name}",
+                                        {
+                                          accept: "application/vnd.github.raw",
+                                          path: ".govuk_dependabot_merger.yml",
+                                        },
+                                      ))
   rescue Octokit::NotFound
     {}
   end

--- a/lib/repos.rb
+++ b/lib/repos.rb
@@ -3,6 +3,6 @@ require_relative "./repo"
 
 class Repos
   def self.all(config_file = File.join(File.dirname(__FILE__), "../config/repos_opted_in.yml"))
-    YAML.load_file(config_file).map { |repo_name| Repo.new(repo_name) }
+    YAML.safe_load_file(config_file).map { |repo_name| Repo.new(repo_name) }
   end
 end


### PR DESCRIPTION
https://github.com/ruby/yaml#security

~~I suspect this isn't exploitable on Ruby 3, but~~ CodeQL is throwing a wobbly about it:
https://github.com/alphagov/govuk-dependabot-merger/security/code-scanning/1

~~Pretty sure `YAML.load` has been equivalent to `YAML.safe_load` for years, but might as well call it explicitly if only to keep CodeQL from crying wolf.~~ edit: nope apparently it just calls Psych.load, which has the same health warning on it 🙃 So I dunno how bad this is.

At least this doesn't work:

```bash
ruby -rYAML -e'YAML.load(STDIN.read)' <<EOF
--- !ruby/struct
inspect: system 'uname -a'
EOF
```

```
3.2.2/lib/ruby/3.2.0/psych/class_loader.rb:99:in `find': Tried to load
  unspecified class: Struct (Psych::DisallowedClass)
```

And presumably it's only gonna slurp in YAML from gems that we already use as dependencies of real projects(?) 

(I didn't go any further down the rabbit hole.)