### PR TITLE
Fix dependency name edge-case

### DIFF
--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -139,10 +139,9 @@ class PullRequest
   end
 
   def tell_dependency_manager_what_dependabot_is_changing
-    dependency_updates = commit_message.scan(/(?:Bump|Updates) `?(\w+)`? from (\d+\.\d+\.\d+) to (\d+\.\d+\.\d+)/)
+    dependency_updates = commit_message.scan(/(?:Bump|Updates) (.+) from (\d+\.\d+\.\d+) to (\d+\.\d+\.\d+)/)
 
-    mentioned_dependencies = dependency_updates.to_h { |name, from_version, to_version| [name, { from_version:, to_version: }] }
-
+    mentioned_dependencies = dependency_updates.to_h { |name, from_version, to_version| [name.gsub(/`/m, ""), { from_version:, to_version: }] }
     lines_removed = gemfile_lock_changes.scan(/^-\s+([a-z\-_]+) \(([0-9.]+)\)$/)
     lines_added = gemfile_lock_changes.scan(/^\+\s+([a-z\-_]+) \(([0-9.]+)\)$/)
 


### PR DESCRIPTION
A recent PR was auto-merged when it should not have been: https://github.com/alphagov/content-data-api/pull/1996

This is because the name of the dependency was not being matched by the regex (`\w` does not support hyphenated names). It therefore looked as though _NO_ dependencies were being updated, and it seemed therefore that there were no top-level dependencies being updated that weren't on the allowlist. govuk-dependabot-merger therefore gave the green light to auto-merge.

Have now tweaked the regex to catch any kind of dependency name. This did break the `multiple_dependencies_commit` spec, because each of its dependencies is wrapped in backticks (as opposed to the single-dependency commits, which had no backticks), so the names weren't matching. I've now added an inline `gsub` to remove the backticks from the names, since they're never actually part of the dependency names.