### PR TITLE
Improve logging output for lib/auto_merger.rb

### DIFF
--- a/lib/auto_merger.rb
+++ b/lib/auto_merger.rb
@@ -13,19 +13,22 @@ class AutoMerger
 
   def merge_dependabot_prs
     Repos.all.each do |repo|
+      if repo.dependabot_pull_requests.count.zero?
+        puts "No Dependabot PRs found for repo '#{repo.name}'."
+      else
+        puts "#{repo.dependabot_pull_requests.count} Dependabot PRs found for repo '#{repo.name}':"
+      end
+
       repo.dependabot_pull_requests.each do |pr|
-        puts "Inspecting #{repo.name}##{pr.number}..."
+        puts "  - Inspecting #{repo.name}##{pr.number}..."
 
         if pr.is_auto_mergeable?
-          puts "...approving! ✅"
+          puts "    ...approving! ✅"
           pr.approve!
-          puts "...merging! 🎉"
+          puts "    ...merging! 🎉"
           pr.merge!
         else
-          pr.reasons_not_to_merge.each do |reason|
-            puts "  Not auto-mergeable: #{reason}"
-          end
-          puts "...skipping."
+          puts "    ...not auto-mergeable: #{pr.reasons_not_to_merge.join(' ')} Skipping."
         end
       end
     end

--- a/lib/repo.rb
+++ b/lib/repo.rb
@@ -11,7 +11,7 @@ class Repo
   end
 
   def dependabot_pull_requests
-    GitHubClient
+    @dependabot_pull_requests ||= GitHubClient
       .instance
       .pull_requests("alphagov/#{@repo_name}", state: :open, sort: :created)
       .select { |api_response| api_response.user.login == "dependabot[bot]" }


### PR DESCRIPTION
This arises from a Dependabot PR that should have been auto merged, but wasn't: https://github.com/alphagov/release/pull/1354#issuecomment-1870301563 It's difficult to debug due to the lack of logs, so this change now ensures we log all of the repos that are scanned, so we can at least see whether it looked at the repo we expect.

Also adds some memoisation to the `dependabot_pull_requests` method, now that we're querying the length of its return value.

Example output:

```
No Dependabot PRs found for repo 'bulk-changer'.
No Dependabot PRs found for repo 'content-data-admin'.
1 Dependabot PRs found for repo 'content-data-api':
  - Inspecting content-data-api#1998...
    ...not auto-mergeable: PR bumps a dependency that is not on the allowlist. Skipping.
No Dependabot PRs found for repo 'gds_zendesk'.
No Dependabot PRs found for repo 'govuk-connect'.
No Dependabot PRs found for repo 'govuk-developer-docs'.
No Dependabot PRs found for repo 'govuk-docker'.
No Dependabot PRs found for repo 'govuk-rota-announcer'.
No Dependabot PRs found for repo 'govuk-rota-generator'.
No Dependabot PRs found for repo 'govuk-technical-2ndline-dashboard'.
No Dependabot PRs found for repo 'govuk-user-reviewer'.
No Dependabot PRs found for repo 'govuk_app_config'.
No Dependabot PRs found for repo 'govuk_test'.
2 Dependabot PRs found for repo 'locations-api':
  - Inspecting locations-api#323...
    ...not auto-mergeable: PR bumps a dependency that is not on the allowlist. Skipping.
  - Inspecting locations-api#329...
    ...not auto-mergeable: PR bumps a dependency that is not on the allowlist. Skipping.
No Dependabot PRs found for repo 'pay-pagerduty'.
No Dependabot PRs found for repo 'plek'.
No Dependabot PRs found for repo 'rack-logstasher'.
No Dependabot PRs found for repo 'release'.
No Dependabot PRs found for repo 'seal'.
1 Dependabot PRs found for repo 'support':
  - Inspecting support#1237...
    ...not auto-mergeable: CI workflow is failing. Skipping.
No Dependabot PRs found for repo 'support-api'.
```