### PR TITLE
Be more defensive in our CI workflow checks

### DIFF
--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -67,6 +67,7 @@ class PullRequest
     # so we need to make the API call manually.
     jobs_url = "https://api.github.com/repos/alphagov/#{@api_response.base.repo.name}/actions/runs/#{ci_workflow_run_id}/jobs"
     jobs = HTTParty.get(jobs_url)["jobs"]
+    return false if jobs.nil?
 
     unfinished_jobs = jobs.reject { |job| job["status"] == "completed" }
     failed_jobs = jobs.reject { |job| %w[success skipped].include?(job["conclusion"]) }

--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -164,7 +164,10 @@ private
     # so we need to make the API call manually.
     ci_workflow_api_response = HTTParty.get("https://api.github.com/repos/alphagov/#{@api_response.base.repo.name}/actions/runs?head_sha=#{@api_response.head.sha}")
     ci_workflow = ci_workflow_api_response["workflow_runs"]&.find { |run| run["name"] == "CI" }
-    return nil if ci_workflow.nil?
+    if ci_workflow.nil?
+      puts "Allegedly no CI workflow in API response for https://api.github.com/repos/alphagov/#{@api_response.base.repo.name}/actions/runs?head_sha=#{@api_response.head.sha}"
+      puts ci_workflow_api_response.inspect
+    end
 
     @ci_workflow_run_id = ci_workflow["id"]
   end

--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -107,7 +107,7 @@ class PullRequest
   end
 
   def head_commit
-    GitHubClient.instance.commit("alphagov/#{@api_response.base.repo.name}", @api_response.head.sha)
+    @head_commit ||= GitHubClient.instance.commit("alphagov/#{@api_response.base.repo.name}", @api_response.head.sha)
   end
 
   def commit_message
@@ -158,7 +158,7 @@ class PullRequest
 private
 
   def ci_workflow_run_id
-    # return @ci_workflow_run_id unless @ci_workflow_run_id.nil?
+    return @ci_workflow_run_id unless @ci_workflow_run_id.nil?
 
     # No method exists for this in Octokit,
     # so we need to make the API call manually.
@@ -166,7 +166,6 @@ private
     ci_workflow = ci_workflow_api_response["workflow_runs"]&.find { |run| run["name"] == "CI" }
     return nil if ci_workflow.nil?
 
-    ci_workflow_run_id = ci_workflow["id"]
-    return ci_workflow_run_id
+    @ci_workflow_run_id = ci_workflow["id"]
   end
 end

--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -163,7 +163,7 @@ private
     # No method exists for this in Octokit,
     # so we need to make the API call manually.
     ci_workflow_api_response = HTTParty.get("https://api.github.com/repos/alphagov/#{@api_response.base.repo.name}/actions/runs?head_sha=#{@api_response.head.sha}")
-    ci_workflow = ci_workflow_api_response["workflow_runs"].find { |run| run["name"] == "CI" }
+    ci_workflow = ci_workflow_api_response["workflow_runs"]&.find { |run| run["name"] == "CI" }
     return nil if ci_workflow.nil?
 
     @ci_workflow_run_id = ci_workflow["id"]

--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -107,7 +107,7 @@ class PullRequest
   end
 
   def head_commit
-    @head_commit ||= GitHubClient.instance.commit("alphagov/#{@api_response.base.repo.name}", @api_response.head.sha)
+    GitHubClient.instance.commit("alphagov/#{@api_response.base.repo.name}", @api_response.head.sha)
   end
 
   def commit_message
@@ -158,7 +158,7 @@ class PullRequest
 private
 
   def ci_workflow_run_id
-    return @ci_workflow_run_id unless @ci_workflow_run_id.nil?
+    # return @ci_workflow_run_id unless @ci_workflow_run_id.nil?
 
     # No method exists for this in Octokit,
     # so we need to make the API call manually.
@@ -166,6 +166,7 @@ private
     ci_workflow = ci_workflow_api_response["workflow_runs"]&.find { |run| run["name"] == "CI" }
     return nil if ci_workflow.nil?
 
-    @ci_workflow_run_id = ci_workflow["id"]
+    ci_workflow_run_id = ci_workflow["id"]
+    return ci_workflow_run_id
   end
 end

--- a/spec/lib/pull_request_spec.rb
+++ b/spec/lib/pull_request_spec.rb
@@ -393,6 +393,13 @@ RSpec.describe PullRequest do
       pr = PullRequest.new(pull_request_api_response)
       expect(pr.validate_ci_passes).to eq(false)
     end
+
+    it "returns false if PR has no CI pipeline" do
+      stub_runs_endpoint(ci_workflow_id, {})
+
+      pr = PullRequest.new(pull_request_api_response)
+      expect(pr.validate_ci_passes).to eq(false)
+    end
   end
 
   describe "#validate_external_config_file" do

--- a/spec/lib/pull_request_spec.rb
+++ b/spec/lib/pull_request_spec.rb
@@ -348,6 +348,13 @@ RSpec.describe PullRequest do
       pr = PullRequest.new(pull_request_api_response)
       expect(pr.validate_ci_workflow_exists).to eq(false)
     end
+
+    it "returns false if there are no workflows in the response" do
+      stub_ci_endpoint({})
+
+      pr = PullRequest.new(pull_request_api_response)
+      expect(pr.validate_ci_workflow_exists).to eq(false)
+    end
   end
 
   describe "#validate_ci_passes" do


### PR DESCRIPTION
See commits for details. We're seeing two different errors appearing on some of our Dependabot Merger runs, which we can handle gracefully by making our code more defensive.

This PR fixes the runs - tested in https://github.com/alphagov/govuk-dependabot-merger/actions/runs/7668289027/job/20899807299.