### PR TITLE
Authenticate `HTTParty` requests to GitHub API

### DIFF
--- a/lib/github_client.rb
+++ b/lib/github_client.rb
@@ -5,27 +5,18 @@ class GitHubAuthException < StandardError; end
 
 class GitHubClient
   def self.instance
-    ensure_token_exists!
-
-    Octokit::Client.new(access_token: ENV["AUTO_MERGE_TOKEN"])
+    Octokit::Client.new(access_token: token)
   end
 
   def self.get(url)
-    HTTParty.get(url, headers: { "Authorization": "Bearer #{GitHubClient.token}" })
+    HTTParty.get(url, headers: { "Authorization": "Bearer #{token}" })
   end
 
   def self.post(url, hash)
-    HTTParty.post(url, body: hash.to_json, headers: { "Authorization": "Bearer #{GitHubClient.token}" })
+    HTTParty.post(url, body: hash.to_json, headers: { "Authorization": "Bearer #{token}" })
   end
 
-  def self.token
-    ensure_token_exists!
-    ENV["AUTO_MERGE_TOKEN"]
-  end
-
-  def self.ensure_token_exists!
-    unless ENV["AUTO_MERGE_TOKEN"]
-      raise GitHubAuthException, "AUTO_MERGE_TOKEN missing"
-    end
+  private_class_method def self.token
+    ENV["AUTO_MERGE_TOKEN"] || raise(GitHubAuthException, "AUTO_MERGE_TOKEN missing")
   end
 end

--- a/lib/github_client.rb
+++ b/lib/github_client.rb
@@ -14,6 +14,10 @@ class GitHubClient
     HTTParty.get(url, headers: { "Authorization": "Bearer #{GitHubClient.token}" })
   end
 
+  def self.post(url, hash)
+    HTTParty.post(url, body: hash.to_json, headers: { "Authorization": "Bearer #{GitHubClient.token}" })
+  end
+
   def self.token
     ensure_token_exists!
     ENV["AUTO_MERGE_TOKEN"]

--- a/lib/github_client.rb
+++ b/lib/github_client.rb
@@ -1,3 +1,4 @@
+require "httparty"
 require "octokit"
 
 class GitHubAuthException < StandardError; end
@@ -7,6 +8,10 @@ class GitHubClient
     ensure_token_exists!
 
     Octokit::Client.new(access_token: ENV["AUTO_MERGE_TOKEN"])
+  end
+
+  def self.get(url)
+    HTTParty.get(url, headers: { "Authorization": "Bearer #{GitHubClient.token}" })
   end
 
   def self.token

--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -66,7 +66,7 @@ class PullRequest
     # No method exists for this in Octokit,
     # so we need to make the API call manually.
     jobs_url = "https://api.github.com/repos/alphagov/#{@api_response.base.repo.name}/actions/runs/#{ci_workflow_run_id}/jobs"
-    jobs = HTTParty.get(jobs_url)["jobs"]
+    jobs = HTTParty.get(jobs_url, headers: { "Authorization": "Bearer #{GitHubClient.token}" })["jobs"]
 
     unfinished_jobs = jobs.reject { |job| job["status"] == "completed" }
     failed_jobs = jobs.reject { |job| %w[success skipped].include?(job["conclusion"]) }
@@ -161,7 +161,10 @@ private
 
     # No method exists for this in Octokit,
     # so we need to make the API call manually.
-    ci_workflow_api_response = HTTParty.get("https://api.github.com/repos/alphagov/#{@api_response.base.repo.name}/actions/runs?head_sha=#{@api_response.head.sha}")
+    ci_workflow_api_response = HTTParty.get(
+      "https://api.github.com/repos/alphagov/#{@api_response.base.repo.name}/actions/runs?head_sha=#{@api_response.head.sha}",
+      headers: { "Authorization": "Bearer #{GitHubClient.token}" },
+    )
     ci_workflow = ci_workflow_api_response["workflow_runs"].find { |run| run["name"] == "CI" }
     return nil if ci_workflow.nil?
 

--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -66,7 +66,7 @@ class PullRequest
     # No method exists for this in Octokit,
     # so we need to make the API call manually.
     jobs_url = "https://api.github.com/repos/alphagov/#{@api_response.base.repo.name}/actions/runs/#{ci_workflow_run_id}/jobs"
-    jobs = HTTParty.get(jobs_url, headers: { "Authorization": "Bearer #{GitHubClient.token}" })["jobs"]
+    jobs = GitHubClient.get(jobs_url)["jobs"]
 
     unfinished_jobs = jobs.reject { |job| job["status"] == "completed" }
     failed_jobs = jobs.reject { |job| %w[success skipped].include?(job["conclusion"]) }
@@ -161,10 +161,7 @@ private
 
     # No method exists for this in Octokit,
     # so we need to make the API call manually.
-    ci_workflow_api_response = HTTParty.get(
-      "https://api.github.com/repos/alphagov/#{@api_response.base.repo.name}/actions/runs?head_sha=#{@api_response.head.sha}",
-      headers: { "Authorization": "Bearer #{GitHubClient.token}" },
-    )
+    ci_workflow_api_response = GitHubClient.get("https://api.github.com/repos/alphagov/#{@api_response.base.repo.name}/actions/runs?head_sha=#{@api_response.head.sha}")
     ci_workflow = ci_workflow_api_response["workflow_runs"].find { |run| run["name"] == "CI" }
     return nil if ci_workflow.nil?
 

--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -84,14 +84,11 @@ class PullRequest
     approval_message = <<~REVIEW_COMMENT
       This PR has been scanned and automatically approved by [govuk-dependabot-merger](https://github.com/alphagov/govuk-dependabot-merger).
     REVIEW_COMMENT
-    response = HTTParty.post(
+    response = GitHubClient.post(
       "https://api.github.com/repos/alphagov/#{@api_response.base.repo.name}/pulls/#{@api_response.number}/reviews",
-      body: {
+      {
         event: "APPROVE",
         body: approval_message,
-      }.to_json,
-      headers: {
-        "Authorization": "Bearer #{GitHubClient.token}",
       },
     )
     if response.code != 200

--- a/spec/lib/github_client_spec.rb
+++ b/spec/lib/github_client_spec.rb
@@ -26,6 +26,20 @@ RSpec.describe GitHubClient do
     end
   end
 
+  describe ".post" do
+    it "should make an authenticated POST request via HTTParty" do
+      url = "http://example.com"
+      hash = { foo: "bar" }
+      json = '{"foo":"bar"}'
+      token = "foo"
+
+      expect(HTTParty).to receive(:post).with(url, body: json, headers: { "Authorization": "Bearer #{token}" })
+
+      ENV["AUTO_MERGE_TOKEN"] = token
+      GitHubClient.post(url, hash)
+    end
+  end
+
   describe ".token" do
     it "should raise an exception if no `AUTO_MERGE_TOKEN` ENV var provided" do
       ENV["AUTO_MERGE_TOKEN"] = nil

--- a/spec/lib/github_client_spec.rb
+++ b/spec/lib/github_client_spec.rb
@@ -14,6 +14,18 @@ RSpec.describe GitHubClient do
     end
   end
 
+  describe ".get" do
+    it "should make an authenticated GET request via HTTParty" do
+      url = "http://example.com"
+      token = "foo"
+
+      expect(HTTParty).to receive(:get).with(url, headers: { "Authorization": "Bearer #{token}" })
+
+      ENV["AUTO_MERGE_TOKEN"] = token
+      GitHubClient.get(url)
+    end
+  end
+
   describe ".token" do
     it "should raise an exception if no `AUTO_MERGE_TOKEN` ENV var provided" do
       ENV["AUTO_MERGE_TOKEN"] = nil

--- a/spec/lib/github_client_spec.rb
+++ b/spec/lib/github_client_spec.rb
@@ -15,6 +15,11 @@ RSpec.describe GitHubClient do
   end
 
   describe ".get" do
+    it "should raise an exception if no `AUTO_MERGE_TOKEN` ENV var provided" do
+      ENV["AUTO_MERGE_TOKEN"] = nil
+      expect { GitHubClient.get("http://example.com") }.to raise_exception(GitHubAuthException, "AUTO_MERGE_TOKEN missing")
+    end
+
     it "should make an authenticated GET request via HTTParty" do
       url = "http://example.com"
       token = "foo"
@@ -27,6 +32,11 @@ RSpec.describe GitHubClient do
   end
 
   describe ".post" do
+    it "should raise an exception if no `AUTO_MERGE_TOKEN` ENV var provided" do
+      ENV["AUTO_MERGE_TOKEN"] = nil
+      expect { GitHubClient.post("http://example.com", {}) }.to raise_exception(GitHubAuthException, "AUTO_MERGE_TOKEN missing")
+    end
+
     it "should make an authenticated POST request via HTTParty" do
       url = "http://example.com"
       hash = { foo: "bar" }
@@ -37,18 +47,6 @@ RSpec.describe GitHubClient do
 
       ENV["AUTO_MERGE_TOKEN"] = token
       GitHubClient.post(url, hash)
-    end
-  end
-
-  describe ".token" do
-    it "should raise an exception if no `AUTO_MERGE_TOKEN` ENV var provided" do
-      ENV["AUTO_MERGE_TOKEN"] = nil
-      expect { GitHubClient.token }.to raise_exception(GitHubAuthException, "AUTO_MERGE_TOKEN missing")
-    end
-
-    it "should return the token" do
-      ENV["AUTO_MERGE_TOKEN"] = "some-value"
-      expect(GitHubClient.token).to eq("some-value")
     end
   end
 end


### PR DESCRIPTION
We were breaching GitHub's rate limits, causing the build to crash:
https://github.com/alphagov/govuk-dependabot-merger/actions/runs/7668518383/job/20900460080

```
<HTTParty::Response:0x1220 parsed_response={"message"=>"API rate limit exceeded for 20.97.191.128. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)", "documentation_url"=>"https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting"}, @response=#<Net::HTTPForbidden 403 rate limit exceeded readbody=true>, @headers={"date"=>["Fri, 26 Jan 2024 13:12:43 GMT"], "server"=>["Varnish"], "strict-transport-security"=>["max-age=31536000; includeSubdomains; preload"], "x-content-type-options"=>["nosniff"], "x-frame-options"=>["deny"], "x-xss-protection"=>["1; mode=block"], "content-security-policy"=>["default-src 'none'; style-src 'unsafe-inline'"], "access-control-allow-origin"=>["*"], "access-control-expose-headers"=>["ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-RateLimit-Used, X-RateLimit-Resource, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-Git
```

This change ensures we pass the auth token with the request, which ups the rate limit from 60 per hour to 5,000 requests per hour:
https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28

Tested this works in https://github.com/alphagov/govuk-dependabot-merger/actions/runs/7668862041/job/20901549529