### PR TITLE
Fix nil dereference in `pull_request.rb`

### DIFF
--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -166,7 +166,7 @@ private
     # No method exists for this in Octokit,
     # so we need to make the API call manually.
     ci_workflow_api_response = GitHubClient.get("https://api.github.com/repos/alphagov/#{@api_response.base.repo.name}/actions/runs?head_sha=#{@api_response.head.sha}")
-    ci_workflow = ci_workflow_api_response["workflow_runs"].find { |run| run["name"] == "CI" }
+    ci_workflow = ci_workflow_api_response["workflow_runs"]&.find { |run| run["name"] == "CI" }
     return nil if ci_workflow.nil?
 
     @ci_workflow_run_id = ci_workflow["id"]


### PR DESCRIPTION
Should fix the `undefined method `find' for nil:NilClass (NoMethodError)` error we're seeing on recent workflow runs: https://github.com/alphagov/govuk-dependabot-merger/actions/runs/7797524406/job/21264292221