### PR TITLE
Raise exception when no workflows are returned

### DIFF
--- a/spec/lib/pull_request_spec.rb
+++ b/spec/lib/pull_request_spec.rb
@@ -360,6 +360,21 @@ RSpec.describe PullRequest do
       pr = PullRequest.new(pull_request_api_response)
       expect(pr.validate_ci_workflow_exists).to eq(false)
     end
+
+    it "should raise an exception if no workflows are returned in the response" do
+      stub_ci_endpoint({ "error": "some GitHub error" })
+
+      pr = PullRequest.new(pull_request_api_response)
+      expected_output = <<~MULTILINE_OUTPUT
+        Error fetching CI workflow in API response for https://api.github.com/repos/alphagov/foo/actions/runs?head_sha=#{sha}
+        {"error":"some GitHub error"}
+      MULTILINE_OUTPUT
+
+      expect { pr.validate_ci_workflow_exists }.to raise_exception(
+        PullRequest::UnexpectedGitHubApiResponse,
+        expected_output.strip!,
+      )
+    end
   end
 
   describe "#validate_ci_passes" do


### PR DESCRIPTION
E.g. if GitHub API returns an error (due to rate limit breach, or lack of permissions on the token) then there won't be a `workflow_runs` property on the JSON response.

Previously, such cases would unhelpfully fail with:

```
`ci_workflow_run_id': undefined method `find' for nil:NilClass (NoMethodError)
    ci_workflow = ci_workflow_api_response["workflow_runs"].find { |run| run["name"] == "CI" }
                                                           ^^^^^
```

At least now, we can see exactly what the `ci_workflow_api_response` is.