### PR TITLE
Add 'Read-only' permission on Actions

### DIFF
--- a/docs/adr/03-access-token-scope.md
+++ b/docs/adr/03-access-token-scope.md
@@ -9,9 +9,10 @@ This repo requires a privileged GitHub token in order to approve and merge pull 
 ## Decision
 
 We'll create a fine grained GitHub personal access token on the [govuk-ci](https://github.com/govuk-ci) user, with the following permissions:
-- Read on metadata
-- Read and write on pull requests
-- Read and write on contents
+- Read-only on Actions
+- Read-only on Metadata
+- Read and write on Pull requests
+- Read and write on Contents
 - Applied to "All repositories" owned by the organisation.
 
 This token will be used as the `AUTO_MERGE_TOKEN` repository secret for govuk-dependabot-merger.


### PR DESCRIPTION
Since this ADR was written, we've started using the GitHub API to retrieve 'actions' (workflows / checks) associated with a Dependabot PR, in order to see if the CI workflow passed. See commit 92961561b17d2f010a7e4b9279c26e346ecefc92.

This recently started causing an exception at runtime: https://github.com/alphagov/govuk-dependabot-merger/actions/runs/7803157224/job/21282271607

```
/home/runner/work/govuk-dependabot-merger/govuk-dependabot-merger/lib/pull_request.rb:173:in `ci_workflow_run_id': Error fetching CI workflow in API response for https://api.github.com/repos/alphagov/govuk-user-reviewer/actions/runs?head_sha=39462535ae2f582246cba4c47082e3e1d5f38e67 (PullRequest::UnexpectedGitHubApiResponse)
{"message":"Resource not accessible by personal access token","documentation_url":"https://docs.github.com/rest/actions/workflow-runs#list-workflow-runs-for-a-repository"}
```

govuk-user-reviewer is a private repository, thus needed extra permissions on the `AUTO_MERGE_TOKEN` token. Adding 'read-only' permissions to the 'Action' scope fixes the runtime error: https://github.com/alphagov/govuk-dependabot-merger/actions/runs/7803209295/job/21282454913