### PR TITLE
Remove info-frontend from govuk-dependabot-merger

### DIFF
--- a/config/repos_opted_in.yml
+++ b/config/repos_opted_in.yml
@@ -39,7 +39,6 @@
 - govuk-user-reviewer
 - hmrc-manuals-api
 - imminence
-- info-frontend
 - link-checker-api
 - local-links-manager
 - locations-api


### PR DESCRIPTION
## What

This line needs to be removed: [https://github.com/alphagov/govuk-dependabot-merger/blob/3206c703b2b4cf2dedef751313b3407485e89471/config/repos\_opted\_in.yml#L42](https://github.com/alphagov/govuk-dependabot-merger/blob/3206c703b2b4cf2dedef751313b3407485e89471/config/repos_opted_in.yml#L42 "‌")

## Why

The info-frontend app has been retired.
[Trello ticket](https://trello.com/c/Ozo2Rpeh/2481-remove-info-frontend-from-govuk-dependabot-merger-xs)