### PR TITLE
Reduce coupling between `PullRequest` and `DependencyManager`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,6 @@ gem "octokit"
 group :development, :test do
   gem "byebug"
   gem "rspec"
-  gem "rubocop-govuk", require: false
+  gem "rubocop-govuk", ">= 4.16", require: false
   gem "webmock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.1.3)
+    activesupport (7.1.3.2)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
@@ -23,8 +23,7 @@ GEM
       bigdecimal
       rexml
     diff-lcs (1.5.1)
-    drb (2.2.0)
-      ruby2_keywords
+    drb (2.2.1)
     faraday (2.9.0)
       faraday-net_http (>= 2.0, < 3.2)
     faraday-net_http (3.1.0)
@@ -33,12 +32,12 @@ GEM
     httparty (0.21.0)
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
-    i18n (1.14.1)
+    i18n (1.14.4)
       concurrent-ruby (~> 1.0)
     json (2.7.1)
     language_server-protocol (3.17.0.3)
     mini_mime (1.1.5)
-    minitest (5.22.2)
+    minitest (5.22.3)
     multi_xml (0.6.0)
     mutex_m (0.2.0)
     net-http (0.4.1)
@@ -53,7 +52,7 @@ GEM
       racc
     public_suffix (5.0.4)
     racc (1.7.3)
-    rack (3.0.9.1)
+    rack (3.0.10)
     rainbow (3.1.1)
     regexp_parser (2.9.0)
     rexml (3.2.6)
@@ -70,7 +69,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.0)
-    rubocop (1.60.2)
+    rubocop (1.62.1)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
@@ -78,34 +77,33 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.30.0, < 2.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.30.0)
-      parser (>= 3.2.1.0)
+    rubocop-ast (1.31.2)
+      parser (>= 3.3.0.4)
     rubocop-capybara (2.20.0)
       rubocop (~> 1.41)
     rubocop-factory_bot (2.25.1)
       rubocop (~> 1.41)
-    rubocop-govuk (4.14.0)
-      rubocop (= 1.60.2)
-      rubocop-ast (= 1.30.0)
-      rubocop-rails (= 2.23.1)
+    rubocop-govuk (4.16.0)
+      rubocop (= 1.62.1)
+      rubocop-ast (= 1.31.2)
+      rubocop-rails (= 2.24.1)
       rubocop-rake (= 0.6.0)
-      rubocop-rspec (= 2.26.1)
-    rubocop-rails (2.23.1)
+      rubocop-rspec (= 2.27.1)
+    rubocop-rails (2.24.1)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.33.0, < 2.0)
-      rubocop-ast (>= 1.30.0, < 2.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
     rubocop-rake (0.6.0)
       rubocop (~> 1.0)
-    rubocop-rspec (2.26.1)
+    rubocop-rspec (2.27.1)
       rubocop (~> 1.40)
       rubocop-capybara (~> 2.17)
       rubocop-factory_bot (~> 2.22)
     ruby-progressbar (1.13.0)
-    ruby2_keywords (0.0.5)
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
@@ -126,7 +124,7 @@ DEPENDENCIES
   httparty
   octokit
   rspec
-  rubocop-govuk
+  rubocop-govuk (>= 4.16)
   webmock
 
 BUNDLED WITH

--- a/lib/change_set.rb
+++ b/lib/change_set.rb
@@ -23,7 +23,13 @@ Change = Struct.new(:dependency, :type) do
   end
 end
 
-ChangeSet = Struct.new(:changes) do
+class ChangeSet
+  attr_accessor :changes
+
+  def initialize(changes = nil)
+    @changes = changes.nil? ? [] : changes
+  end
+
   def self.from_commit_message(commit_message)
     commit_message = commit_message
       .split("---", 2)[1]

--- a/lib/change_set.rb
+++ b/lib/change_set.rb
@@ -1,0 +1,43 @@
+Dependency = Struct.new(:name) do
+  def internal?
+    Net::HTTP.get(URI("https://rubygems.org/api/v1/gems/#{name}/owners.yaml"))
+      .then { |response| YAML.safe_load response }
+      .any? { |owner| owner["handle"] == "govuk" }
+  end
+end
+
+Change = Struct.new(:dependency, :type) do
+  def self.type_from_dependabot_type(dependabot_type)
+    case dependabot_type
+    when "version-update:semver-major"
+      :major
+    when "version-update:semver-minor"
+      :minor
+    when "version-update:semver-patch"
+      :patch
+    else
+      # As of March 2024, these are the only options Dependabot can return
+      # If they add more in the future, we will need to update this
+      raise "Unrecognised update-type: #{dependabot_type}"
+    end
+  end
+end
+
+ChangeSet = Struct.new(:changes) do
+  def self.from_commit_message(commit_message)
+    commit_message = commit_message
+      .split("---", 2)[1]
+      .split("...", 2)[0]
+
+    YAML.safe_load(commit_message)
+      .fetch("updated-dependencies")
+      .map { |dep|
+        dependency = Dependency.new(dep["dependency-name"])
+        type = Change.type_from_dependabot_type(dep["update-type"])
+        Change.new(dependency, type)
+      }
+      .then { |changes| ChangeSet.new changes }
+  rescue StandardError
+    raise "Commit message is not in the expected format"
+  end
+end

--- a/lib/dependency_manager.rb
+++ b/lib/dependency_manager.rb
@@ -1,82 +1,30 @@
-require "httparty"
-
-Update = Struct.new(:previous_version, :next_version) do
-  def type
-    [previous_version, next_version].each { |version| DependencyManager.validate_semver(version) }
-
-    prev_major, prev_minor, prev_patch = previous_version.split(".").map(&:to_i)
-    next_major, next_minor, next_patch = next_version.split(".").map(&:to_i)
-    return :major if (next_major - prev_major).positive?
-    return :minor if (next_minor - prev_minor).positive?
-    return :patch if (next_patch - prev_patch).positive?
-
-    :unchanged
-  end
-end
-
 class DependencyManager
-  attr_reader :allowed_dependency_updates, :proposed_dependency_updates
+  attr_reader :allowed_dependency_updates
+  attr_accessor :change_set
 
   def initialize
     @allowed_dependency_updates = []
-    @proposed_dependency_updates = Hash.new { |h, v| h[v] = Update.new }
+    @change_set = ChangeSet.new
   end
 
   def allow_dependency_update(name:, allowed_semver_bumps:)
     allowed_dependency_updates << { name:, allowed_semver_bumps: }
   end
 
-  def add_dependency(name:, version:)
-    raise DependencyConflict unless proposed_dependency_updates[name].next_version.nil?
-
-    proposed_dependency_updates[name].next_version = version
-    validate_dependency_changes!
-  end
-
-  def remove_dependency(name:, version:)
-    raise DependencyConflict unless proposed_dependency_updates[name].previous_version.nil?
-
-    proposed_dependency_updates[name].previous_version = version
-    validate_dependency_changes!
-  end
-
-  def validate_dependency_changes!
-    raise InvalidInput if proposed_dependency_updates.keys.include?(nil)
-
-    proposed_dependency_updates.each_value do |update|
-      raise InvalidInput if update.previous_version.nil? && update.next_version.nil?
-
-      DependencyManager.validate_semver(update.previous_version) if update.previous_version
-      DependencyManager.validate_semver(update.next_version) if update.next_version
-    end
-  end
-
   def all_proposed_dependencies_on_allowlist?
-    proposed_dependency_updates.keys.all? do |name|
-      allowed_dependency_updates.map { |dep| dep[:name] }.include? name
+    change_set.changes.all? do |change|
+      allowed_dependency_updates.map { |dep| dep[:name] }.include? change.dependency.name
     end
   end
 
   def all_proposed_updates_semver_allowed?
-    proposed_dependency_updates.all? do |name, update|
-      dependency = allowed_dependency_updates.find { |dep| dep[:name] == name }
-      dependency.nil? || dependency[:allowed_semver_bumps].include?(update.type.to_s)
+    change_set.changes.all? do |change|
+      dependency = allowed_dependency_updates.find { |dep| dep[:name] == change.dependency.name }
+      dependency.nil? || dependency[:allowed_semver_bumps].include?(change.type.to_s)
     end
   end
 
   def all_proposed_dependencies_are_internal?
-    proposed_dependency_updates.keys.all? do |name|
-      HTTParty.get("https://rubygems.org/api/v1/gems/#{name}/owners.yaml")
-        .then { |response| YAML.safe_load response }
-        .any? { |owner| owner["handle"] == "govuk" }
-    end
+    change_set.changes.all? { |change| change.dependency.internal? }
   end
-
-  def self.validate_semver(str)
-    raise SemverException unless str.match?(/^[0-9]+\.[0-9]+\.[0-9]+$/)
-  end
-
-  class DependencyConflict < StandardError; end
-  class InvalidInput < StandardError; end
-  class SemverException < StandardError; end
 end

--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -121,13 +121,12 @@ class PullRequest
   end
 
   def remote_config
-    @remote_config ||= YAML.safe_load(GitHubClient.instance.contents(
-                                        "alphagov/#{@api_response.base.repo.name}",
-                                        {
-                                          accept: "application/vnd.github.raw",
-                                          path: ".govuk_dependabot_merger.yml",
-                                        },
-                                      ))
+    @remote_config ||= GitHubClient.instance
+      .contents(
+        "alphagov/#{@api_response.base.repo.name}",
+        path: ".govuk_dependabot_merger.yml",
+      )
+      .then { |content| YAML.safe_load content }
   rescue Octokit::NotFound
     { "error": "404" }
   rescue Psych::SyntaxError

--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -34,7 +34,7 @@ class PullRequest
       reasons_not_to_merge << "The remote .govuk_dependabot_merger.yml file does not have the expected YAML structure."
     else
       tell_dependency_manager_what_dependencies_are_allowed
-      tell_dependency_manager_what_dependabot_is_changing
+      dependency_manager.change_set = ChangeSet.from_commit_message(commit_message)
 
       if !dependency_manager.all_proposed_dependencies_on_allowlist?
         reasons_not_to_merge << "PR bumps a dependency that is not on the allowlist."
@@ -135,10 +135,6 @@ class PullRequest
         allowed_semver_bumps: dependency["allowed_semver_bumps"],
       )
     end
-  end
-
-  def tell_dependency_manager_what_dependabot_is_changing
-    dependency_manager.change_set = ChangeSet.from_commit_message(commit_message)
   end
 
 private

--- a/spec/lib/change_set_spec.rb
+++ b/spec/lib/change_set_spec.rb
@@ -1,0 +1,125 @@
+require_relative "../../lib/change_set"
+
+RSpec.describe Dependency do
+  describe "#internal?" do
+    it "returns true if the dependency is owned by govuk" do
+      stub_request(:get, "https://rubygems.org/api/v1/gems/foo/owners.yaml")
+        .to_return(
+          body: <<~BODY,
+            - id: 59597
+              handle: govuk
+          BODY
+        )
+
+      expect(Dependency.new("foo").internal?).to eq(true)
+    end
+
+    it "returns false if the dependency is not owned by govuk" do
+      stub_request(:get, "https://rubygems.org/api/v1/gems/foo/owners.yaml")
+        .to_return(
+          body: <<~BODY,
+            - id: 123
+              handle: some-malicious-actor
+          BODY
+        )
+
+      expect(Dependency.new("foo").internal?).to eq(false)
+    end
+  end
+end
+
+RSpec.describe Change do
+  describe ".type_from_dependabot_type" do
+    it "converts a dependabot update-type into a symbol" do
+      expect(Change.type_from_dependabot_type("version-update:semver-major")).to eq(:major)
+      expect(Change.type_from_dependabot_type("version-update:semver-minor")).to eq(:minor)
+      expect(Change.type_from_dependabot_type("version-update:semver-patch")).to eq(:patch)
+      expect { Change.type_from_dependabot_type("foo") }.to raise_error(RuntimeError, "Unrecognised update-type: foo")
+    end
+  end
+end
+
+RSpec.describe ChangeSet do
+  def single_dependency_commit
+    <<~TEXT
+      Bump govuk_publishing_components from 35.7.0 to 35.8.0
+
+      Bumps [govuk_publishing_components](https://github.com/alphagov/govuk_publishing_components) from 35.7.0 to 35.8.0.
+      - [Changelog](https://github.com/alphagov/govuk_publishing_components/blob/main/CHANGELOG.md)
+      - [Commits](alphagov/govuk_publishing_components@v35.7.0...v35.8.0)
+
+      ---
+      updated-dependencies:
+      - dependency-name: govuk_publishing_components
+        dependency-type: direct:production
+        update-type: version-update:semver-minor
+      ...
+
+      Signed-off-by: dependabot[bot] <support@github.com>
+    TEXT
+  end
+
+  def multiple_dependencies_commit
+    <<~TEXT
+      Bump rack, rails and govuk_sidekiq
+
+      Bumps [rack](https://github.com/rack/rack), [rails](https://github.com/rails/rails) and [govuk_sidekiq](https://github.com/alphagov/govuk_sidekiq). These dependencies needed to be updated together.
+
+      Updates `rack` from 1.0.0 to 1.1.0
+      - [Release notes](https://github.com/rack/rack/releases)
+      - [Changelog](https://github.com/rack/rack/blob/main/CHANGELOG.md)
+      - [Commits](rack/rack@v1.0.0...v1.1.0)
+
+      Updates `rails` from 7.0.8 to 7.1.1
+      - [Release notes](https://github.com/rails/rails/releases)
+      - [Commits](rails/rails@v7.0.8...v7.1.1)
+
+      Updates `govuk_sidekiq` from 5.7.0 to 5.8.0
+      - [Changelog](https://github.com/alphagov/govuk_sidekiq/blob/main/CHANGELOG.md)
+      - [Commits](alphagov/govuk_sidekiq@v5.7.0...v5.8.0)
+
+      ---
+      updated-dependencies:
+      - dependency-name: rack
+        dependency-type: direct:development
+        update-type: version-update:semver-minor
+      - dependency-name: rails
+        dependency-type: direct:production
+        update-type: version-update:semver-minor
+      - dependency-name: govuk_sidekiq
+        dependency-type: direct:production
+        update-type: version-update:semver-minor
+      ...
+
+      Signed-off-by: dependabot[bot] <support@github.com>
+    TEXT
+  end
+
+  describe ".from_commit_message" do
+    it "parses the commit message to discover the changed dependencies" do
+      change_set = ChangeSet.from_commit_message single_dependency_commit
+      expect(change_set.changes).to eq([
+        Change.new(Dependency.new("govuk_publishing_components"), :minor),
+      ])
+    end
+
+    it "supports commits that change more than one dependency" do
+      change_set = ChangeSet.from_commit_message multiple_dependencies_commit
+      expect(change_set.changes).to eq([
+        Change.new(Dependency.new("rack"), :minor),
+        Change.new(Dependency.new("rails"), :minor),
+        Change.new(Dependency.new("govuk_sidekiq"), :minor),
+      ])
+    end
+
+    it "raises an error if the commit message is not in the expected format" do
+      expect {
+        ChangeSet.from_commit_message("Hello world!")
+      }.to raise_error(RuntimeError, "Commit message is not in the expected format")
+
+      expect {
+        ChangeSet.from_commit_message("foo\n---\nsyntax: error:\n...\nbar")
+      }.to raise_error(RuntimeError, "Commit message is not in the expected format")
+    end
+  end
+end

--- a/spec/lib/pull_request_spec.rb
+++ b/spec/lib/pull_request_spec.rb
@@ -451,18 +451,6 @@ RSpec.describe PullRequest do
     end
   end
 
-  describe "#tell_dependency_manager_what_dependabot_is_changing" do
-    it "delegates to ChangeSet.from_commit_message" do
-      pr = PullRequest.new(pull_request_api_response)
-
-      commit_message = "foo"
-      expect(pr).to receive(:commit_message).and_return(commit_message)
-      expect(ChangeSet).to receive(:from_commit_message).with(commit_message)
-
-      pr.tell_dependency_manager_what_dependabot_is_changing
-    end
-  end
-
   describe "#merge!" do
     it "should make an API call to merge the PR" do
       pr = PullRequest.new(pull_request_api_response)


### PR DESCRIPTION
[Trello card](https://trello.com/c/pOBu4Y90/3452-change-govuk-dependabot-merger-api-5)

More refactoring to try and reduce coupling between `PullRequest` (and its spec) and `DependencyManager`. This should hopefully make it easier to change the behaviour of `DependencyManager` without breaking all of the tests in `PullRequest`.

Also includes a few other minor readibility improvements.

This PR will probably need some changes before it can be merged, but as today is my last day on GOV.UK someone else might need to take it over the finish line.