### PR TITLE
Fix dependabot merger script

### DIFF
--- a/lib/dependency_manager.rb
+++ b/lib/dependency_manager.rb
@@ -1,3 +1,5 @@
+require_relative "./change_set"
+
 class DependencyManager
   attr_reader :allowed_dependency_updates
   attr_accessor :change_set

--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -1,4 +1,5 @@
 require "yaml"
+require_relative "./change_set"
 require_relative "./dependency_manager"
 require_relative "./github_client"
 require_relative "./version"

--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -120,7 +120,10 @@ class PullRequest
     @remote_config ||= GitHubClient.instance
       .contents(
         "alphagov/#{@api_response.base.repo.name}",
-        path: ".govuk_dependabot_merger.yml",
+        {
+          accept: "application/vnd.github.raw",
+          path: ".govuk_dependabot_merger.yml",
+        },
       )
       .then { |content| YAML.safe_load content }
   rescue Octokit::NotFound


### PR DESCRIPTION
Some hotfixes for issues introduced in #53.

Dependabot merger script was broken: https://github.com/alphagov/govuk-dependabot-merger/actions/runs/8520598260/job/23337048577

Now fixed: https://github.com/alphagov/govuk-dependabot-merger/actions/runs/8520692515/job/23337331873