### PR TITLE
Move remote config fetching into the Repo class

### DIFF
--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -10,7 +10,7 @@ class PullRequest
 
   attr_reader :dependency_manager, :reasons_not_to_merge
 
-  def initialize(api_response, dependency_manager = DependencyManager.new)
+  def initialize(api_response, dependency_manager: DependencyManager.new)
     @api_response = api_response
     @dependency_manager = dependency_manager
     @reasons_not_to_merge = []

--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -10,8 +10,9 @@ class PullRequest
 
   attr_reader :dependency_manager, :reasons_not_to_merge
 
-  def initialize(api_response, dependency_manager: DependencyManager.new)
+  def initialize(api_response, remote_config, dependency_manager: DependencyManager.new)
     @api_response = api_response
+    @remote_config = remote_config
     @dependency_manager = dependency_manager
     @reasons_not_to_merge = []
   end
@@ -78,12 +79,12 @@ class PullRequest
   end
 
   def validate_external_config_file_exists
-    remote_config[:error] != "404"
+    @remote_config["error"] != "404"
   end
 
   def validate_external_config_file_contents
-    remote_config[:error] != "syntax" &&
-      remote_config["api_version"] == DependabotAutoMerge::VERSION
+    @remote_config["error"] != "syntax" &&
+      @remote_config["api_version"] == DependabotAutoMerge::VERSION
   end
 
   def approve!
@@ -116,24 +117,8 @@ class PullRequest
     head_commit.commit.message
   end
 
-  def remote_config
-    @remote_config ||= GitHubClient.instance
-      .contents(
-        "alphagov/#{@api_response.base.repo.name}",
-        {
-          accept: "application/vnd.github.raw",
-          path: ".govuk_dependabot_merger.yml",
-        },
-      )
-      .then { |content| YAML.safe_load content }
-  rescue Octokit::NotFound
-    { "error": "404" }
-  rescue Psych::SyntaxError
-    { "error": "syntax" }
-  end
-
   def tell_dependency_manager_what_dependencies_are_allowed
-    remote_config["auto_merge"].each do |dependency|
+    @remote_config["auto_merge"].each do |dependency|
       dependency_manager.allow_dependency_update(
         name: dependency["dependency"],
         allowed_semver_bumps: dependency["allowed_semver_bumps"],

--- a/lib/repo.rb
+++ b/lib/repo.rb
@@ -28,10 +28,10 @@ Repo = Struct.new(:name) do
       .instance
       .pull_requests("alphagov/#{name}", state: :open, sort: :created)
       .select { |api_response| api_response.user.login == "dependabot[bot]" }
-      .map { |api_response| PullRequest.new(api_response) }
+      .map { |api_response| PullRequest.new(api_response, govuk_dependabot_merger_config) }
   end
 
   def dependabot_pull_request(pr_number)
-    PullRequest.new(GitHubClient.instance.pull_request("alphagov/#{name}", pr_number))
+    PullRequest.new(GitHubClient.instance.pull_request("alphagov/#{name}", pr_number), govuk_dependabot_merger_config)
   end
 end

--- a/lib/repo.rb
+++ b/lib/repo.rb
@@ -17,6 +17,8 @@ Repo = Struct.new(:name) do
         },
       )
       .then { |content| YAML.safe_load(content) }
+  rescue Octokit::NotFound
+    { "error" => "404" }
   rescue Psych::SyntaxError
     { "error" => "syntax" }
   end

--- a/lib/repo.rb
+++ b/lib/repo.rb
@@ -17,6 +17,8 @@ Repo = Struct.new(:name) do
         },
       )
       .then { |content| YAML.safe_load(content) }
+  rescue Psych::SyntaxError
+    { "error" => "syntax" }
   end
 
   def dependabot_pull_requests

--- a/lib/repo.rb
+++ b/lib/repo.rb
@@ -7,6 +7,18 @@ Repo = Struct.new(:name) do
     YAML.safe_load_file(config_file).map { |repo_name| Repo.new(repo_name) }
   end
 
+  def govuk_dependabot_merger_config
+    GitHubClient.instance
+      .contents(
+        "alphagov/#{name}",
+        {
+          accept: "application/vnd.github.raw",
+          path: ".govuk_dependabot_merger.yml",
+        },
+      )
+      .then { |content| YAML.safe_load(content) }
+  end
+
   def dependabot_pull_requests
     @dependabot_pull_requests ||= GitHubClient
       .instance

--- a/spec/lib/pull_request_spec.rb
+++ b/spec/lib/pull_request_spec.rb
@@ -23,6 +23,13 @@ RSpec.describe PullRequest do
     TEXT
   end
 
+  def create_pull_request_instance(govuk_dependabot_merger_config: remote_config, dependency_manager: DependencyManager.new)
+    pr = PullRequest.new(pull_request_api_response, govuk_dependabot_merger_config, dependency_manager:)
+    allow(pr).to receive(:validate_single_commit).and_return(true)
+    allow(pr).to receive(:validate_files_changed).and_return(true)
+    pr
+  end
+
   let(:repo_name) { "foo" }
   let(:sha) { "ee241dea8da11aff8e575941c138a7f34ddb1a51" }
   let(:pull_request_api_response) do
@@ -88,17 +95,31 @@ RSpec.describe PullRequest do
       ],
     }
   end
-  let(:external_config_file_api_url) { "https://api.github.com/repos/alphagov/#{repo_name}/contents/.govuk_dependabot_merger.yml" }
+  let(:remote_config) do
+    {
+      "api_version" => 1,
+      "auto_merge" => [
+        {
+          "dependency" => "govuk_publishing_components",
+          "allowed_semver_bumps" => %w[patch minor],
+        },
+        {
+          "dependency" => "rubocop-govuk",
+          "allowed_semver_bumps" => %w[patch minor],
+        },
+      ],
+    }
+  end
 
   describe "#initialize" do
-    it "should take a GitHub API response shaped pull request" do
-      PullRequest.new(pull_request_api_response)
+    it "should take a GitHub API response shaped pull request and remote config hash" do
+      PullRequest.new(pull_request_api_response, remote_config)
     end
   end
 
   describe "#number" do
     it "should return the number of the PR" do
-      pr = PullRequest.new(pull_request_api_response)
+      pr = PullRequest.new(pull_request_api_response, remote_config)
       expect(pr.number).to eq(1)
     end
   end
@@ -148,7 +169,6 @@ RSpec.describe PullRequest do
 
     it "should make a call to DependencyManager.all_proposed_dependencies_on_allowlist?" do
       stub_successful_check_run
-      stub_remote_allowlist
       stub_remote_commit(head_commit_api_response)
       mock_dependency_manager = create_mock_dependency_manager
 
@@ -164,7 +184,6 @@ RSpec.describe PullRequest do
 
     it "should make a call to DependencyManager.all_proposed_updates_semver_allowed?" do
       stub_successful_check_run
-      stub_remote_allowlist
       stub_remote_commit(head_commit_api_response)
       mock_dependency_manager = create_mock_dependency_manager
 
@@ -180,7 +199,6 @@ RSpec.describe PullRequest do
 
     it "should make a call to DependencyManager.all_proposed_dependencies_are_internal?" do
       stub_successful_check_run
-      stub_remote_allowlist
       stub_remote_commit(head_commit_api_response)
       mock_dependency_manager = create_mock_dependency_manager
 
@@ -215,15 +233,6 @@ RSpec.describe PullRequest do
       ])
     end
 
-    def create_pull_request_instance(dependency_manager: DependencyManager.new)
-      pr = PullRequest.new(pull_request_api_response, dependency_manager:)
-      allow(pr).to receive(:validate_single_commit).and_return(true)
-      allow(pr).to receive(:validate_files_changed).and_return(true)
-      allow(pr).to receive(:validate_external_config_file_exists).and_return(true)
-      allow(pr).to receive(:validate_external_config_file_contents).and_return(true)
-      pr
-    end
-
     def create_mock_dependency_manager
       mock_dependency_manager = double("DependencyManager", all_proposed_dependencies_on_allowlist?: false)
       allow(mock_dependency_manager).to receive(:allow_dependency_update)
@@ -251,7 +260,7 @@ RSpec.describe PullRequest do
       stub_request(:get, commit_api_url)
         .to_return(status: 200, body: [commit_response])
 
-      pr = PullRequest.new(pull_request_api_response)
+      pr = PullRequest.new(pull_request_api_response, remote_config)
       expect(pr.validate_single_commit).to eq(true)
     end
 
@@ -259,7 +268,7 @@ RSpec.describe PullRequest do
       stub_request(:get, commit_api_url)
         .to_return(status: 200, body: [commit_response, commit_response])
 
-      pr = PullRequest.new(pull_request_api_response)
+      pr = PullRequest.new(pull_request_api_response, remote_config)
       expect(pr.validate_single_commit).to eq(false)
     end
   end
@@ -268,7 +277,7 @@ RSpec.describe PullRequest do
     it "returns true if PR only changes Gemfile.lock" do
       stub_remote_commit(head_commit_api_response)
 
-      pr = PullRequest.new(pull_request_api_response)
+      pr = PullRequest.new(pull_request_api_response, remote_config)
       expect(pr.validate_files_changed).to eq(true)
     end
 
@@ -276,7 +285,7 @@ RSpec.describe PullRequest do
       head_commit_api_response[:files][0][:filename] = "something_else.rb"
       stub_remote_commit(head_commit_api_response)
 
-      pr = PullRequest.new(pull_request_api_response)
+      pr = PullRequest.new(pull_request_api_response, remote_config)
       expect(pr.validate_files_changed).to eq(false)
     end
   end
@@ -289,7 +298,7 @@ RSpec.describe PullRequest do
         ],
       })
 
-      pr = PullRequest.new(pull_request_api_response)
+      pr = PullRequest.new(pull_request_api_response, remote_config)
       expect(pr.validate_ci_workflow_exists).to eq(true)
     end
 
@@ -300,14 +309,14 @@ RSpec.describe PullRequest do
         ],
       })
 
-      pr = PullRequest.new(pull_request_api_response)
+      pr = PullRequest.new(pull_request_api_response, remote_config)
       expect(pr.validate_ci_workflow_exists).to eq(false)
     end
 
     it "should raise an exception if no workflows are returned in the response" do
       stub_ci_endpoint({ "error": "some GitHub error" })
 
-      pr = PullRequest.new(pull_request_api_response)
+      pr = PullRequest.new(pull_request_api_response, remote_config)
       expected_output = <<~MULTILINE_OUTPUT
         Error fetching CI workflow in API response for https://api.github.com/repos/alphagov/foo/actions/runs?head_sha=#{sha}
         {"error":"some GitHub error"}
@@ -338,7 +347,7 @@ RSpec.describe PullRequest do
         ],
       })
 
-      pr = PullRequest.new(pull_request_api_response)
+      pr = PullRequest.new(pull_request_api_response, remote_config)
       expect(pr.validate_ci_passes).to eq(true)
     end
 
@@ -349,7 +358,7 @@ RSpec.describe PullRequest do
         ],
       })
 
-      pr = PullRequest.new(pull_request_api_response)
+      pr = PullRequest.new(pull_request_api_response, remote_config)
       expect(pr.validate_ci_passes).to eq(false)
     end
 
@@ -360,69 +369,33 @@ RSpec.describe PullRequest do
         ],
       })
 
-      pr = PullRequest.new(pull_request_api_response)
+      pr = PullRequest.new(pull_request_api_response, remote_config)
       expect(pr.validate_ci_passes).to eq(false)
     end
   end
 
   describe "#validate_external_config_file_exists" do
     it "returns false if there is no automerge config file in the repo" do
-      stub_request(:get, external_config_file_api_url)
-        .to_return(status: 404)
-
-      pr = PullRequest.new(pull_request_api_response)
+      pr = PullRequest.new(pull_request_api_response, { "error" => "404" })
       expect(pr.validate_external_config_file_exists).to eq(false)
     end
 
     it "returns true if the automerge config file exists" do
-      stub_request(:get, external_config_file_api_url)
-        .to_return(status: 200, body: "{}")
-
-      pr = PullRequest.new(pull_request_api_response)
+      pr = create_pull_request_instance
       expect(pr.validate_external_config_file_exists).to eq(true)
     end
   end
 
   describe "#validate_external_config_file_contents" do
     it "returns false if the automerge config file is on a different version" do
-      contents_api_response = <<~EXTERNAL_CONFIG_YAML
-        api_version: -1
-        foo: bar
-      EXTERNAL_CONFIG_YAML
+      remote_config = { "api_version" => -1 }
 
-      stub_request(:get, external_config_file_api_url)
-        .to_return(status: 200, body: contents_api_response.to_json, headers: { "Content-Type": "application/json" })
-
-      pr = PullRequest.new(pull_request_api_response)
-      expect(pr.validate_external_config_file_contents).to eq(false)
-    end
-
-    it "returns false if the config file is not in the right YAML format" do
-      contents_api_response = <<~EXTERNAL_CONFIG_YAML
-        api_version: 1
-        auto_merge:
-          - dependency: govuk_publishing_components
-            allowed_semver_bumps:
-              - patch
-              - minor
-        # note that the below is outdented too far
-        - dependency: rubocop-govuk
-          allowed_semver_bumps:
-            - patch
-            - minor
-      EXTERNAL_CONFIG_YAML
-
-      stub_request(:get, external_config_file_api_url)
-        .to_return(status: 200, body: contents_api_response.to_json, headers: { "Content-Type": "application/json" })
-
-      pr = PullRequest.new(pull_request_api_response)
+      pr = PullRequest.new(pull_request_api_response, remote_config)
       expect(pr.validate_external_config_file_contents).to eq(false)
     end
 
     it "returns true if the automerge config file contains nothing unexpected" do
-      stub_remote_allowlist
-
-      pr = PullRequest.new(pull_request_api_response)
+      pr = create_pull_request_instance
       expect(pr.validate_external_config_file_contents).to eq(true)
     end
   end
@@ -431,7 +404,7 @@ RSpec.describe PullRequest do
     let(:approval_api_url) { "https://api.github.com/repos/alphagov/#{repo_name}/pulls/1/reviews" }
 
     it "should make an API call to approve the PR" do
-      pr = PullRequest.new(pull_request_api_response)
+      pr = PullRequest.new(pull_request_api_response, remote_config)
       stub_request(:post, approval_api_url).with(
         body: {
           "event": "APPROVE",
@@ -444,7 +417,7 @@ RSpec.describe PullRequest do
     end
 
     it "should raise an exception if request unauthorised" do
-      pr = PullRequest.new(pull_request_api_response)
+      pr = PullRequest.new(pull_request_api_response, remote_config)
       stub_request(:post, approval_api_url).to_return(status: 403)
 
       expect { pr.approve! }.to raise_exception(PullRequest::CannotApproveException)
@@ -453,7 +426,7 @@ RSpec.describe PullRequest do
 
   describe "#merge!" do
     it "should make an API call to merge the PR" do
-      pr = PullRequest.new(pull_request_api_response)
+      pr = PullRequest.new(pull_request_api_response, remote_config)
       stub_request(:put, "https://api.github.com/repos/alphagov/#{repo_name}/pulls/1/merge").to_return(status: 200)
 
       pr.merge!
@@ -489,22 +462,4 @@ RSpec.describe PullRequest do
     stub_request(:get, "https://api.github.com/repos/alphagov/#{repo_name}/actions/runs/#{ci_workflow_id}/jobs")
       .to_return(status: 200, body: ci_workflow_api_response.to_json, headers: { "Content-Type": "application/json" })
   end
-end
-
-def stub_remote_allowlist
-  contents_api_response = <<~EXTERNAL_CONFIG_YAML
-    api_version: 1
-    auto_merge:
-      - dependency: govuk_publishing_components
-        allowed_semver_bumps:
-          - patch
-          - minor
-      - dependency: rubocop-govuk
-        allowed_semver_bumps:
-          - patch
-          - minor
-  EXTERNAL_CONFIG_YAML
-
-  stub_request(:get, external_config_file_api_url)
-    .to_return(status: 200, body: contents_api_response.to_json, headers: { "Content-Type": "application/json" })
 end

--- a/spec/lib/pull_request_spec.rb
+++ b/spec/lib/pull_request_spec.rb
@@ -155,7 +155,7 @@ RSpec.describe PullRequest do
       allow(mock_dependency_manager).to receive(:all_proposed_dependencies_on_allowlist?).and_return(false)
       expect(mock_dependency_manager).to receive(:all_proposed_dependencies_on_allowlist?)
 
-      pr = create_pull_request_instance(mock_dependency_manager)
+      pr = create_pull_request_instance(dependency_manager: mock_dependency_manager)
       pr.is_auto_mergeable?
       expect(pr.reasons_not_to_merge).to eq([
         "PR bumps a dependency that is not on the allowlist.",
@@ -171,7 +171,7 @@ RSpec.describe PullRequest do
       allow(mock_dependency_manager).to receive(:all_proposed_updates_semver_allowed?).and_return(false)
       expect(mock_dependency_manager).to receive(:all_proposed_updates_semver_allowed?)
 
-      pr = create_pull_request_instance(mock_dependency_manager)
+      pr = create_pull_request_instance(dependency_manager: mock_dependency_manager)
       pr.is_auto_mergeable?
       expect(pr.reasons_not_to_merge).to eq([
         "PR bumps a dependency to a higher semver than is allowed.",
@@ -187,7 +187,7 @@ RSpec.describe PullRequest do
       allow(mock_dependency_manager).to receive(:all_proposed_dependencies_are_internal?).and_return(false)
       expect(mock_dependency_manager).to receive(:all_proposed_dependencies_are_internal?)
 
-      pr = create_pull_request_instance(mock_dependency_manager)
+      pr = create_pull_request_instance(dependency_manager: mock_dependency_manager)
       pr.is_auto_mergeable?
       expect(pr.reasons_not_to_merge).to eq([
         "PR bumps an external dependency.",
@@ -215,8 +215,8 @@ RSpec.describe PullRequest do
       ])
     end
 
-    def create_pull_request_instance(dependency_manager = DependencyManager.new)
-      pr = PullRequest.new(pull_request_api_response, dependency_manager)
+    def create_pull_request_instance(dependency_manager: DependencyManager.new)
+      pr = PullRequest.new(pull_request_api_response, dependency_manager:)
       allow(pr).to receive(:validate_single_commit).and_return(true)
       allow(pr).to receive(:validate_files_changed).and_return(true)
       allow(pr).to receive(:validate_external_config_file_exists).and_return(true)

--- a/spec/lib/repo_spec.rb
+++ b/spec/lib/repo_spec.rb
@@ -38,6 +38,29 @@ RSpec.describe Repo do
         ],
       })
     end
+
+    it "should return an error hash if the YAML is malformed" do
+      config = <<~EXTERNAL_CONFIG_YAML
+        api_version: 1
+        auto_merge:
+          - dependency: govuk_publishing_components
+            allowed_semver_bumps:
+              - patch
+              - minor
+        # note that the below is outdented too far
+        - dependency: rubocop-govuk
+          allowed_semver_bumps:
+            - patch
+            - minor
+      EXTERNAL_CONFIG_YAML
+      stub_request(:get, external_config_file_api_url)
+        .to_return(status: 200, body: config.to_json, headers: { "Content-Type": "application/json" })
+
+      repo = Repo.new(repo_name)
+      expect(repo.govuk_dependabot_merger_config).to eq({
+        "error" => "syntax",
+      })
+    end
   end
 
   describe "#dependabot_pull_requests" do

--- a/spec/lib/repo_spec.rb
+++ b/spec/lib/repo_spec.rb
@@ -3,6 +3,9 @@ require_relative "../../lib/repo"
 RSpec.describe Repo do
   before { set_up_mock_token }
 
+  let(:repo_name) { "foo" }
+  let(:external_config_file_api_url) { "https://api.github.com/repos/alphagov/#{repo_name}/contents/.govuk_dependabot_merger.yml" }
+
   describe ".all" do
     it "should return an array of Repo objects" do
       repos = Repo.all(File.join(File.dirname(__FILE__), "../config/test_repos_opted_in.yml"))
@@ -12,9 +15,6 @@ RSpec.describe Repo do
   end
 
   describe "#govuk_dependabot_merger_config" do
-    let(:repo_name) { "foo" }
-    let(:external_config_file_api_url) { "https://api.github.com/repos/alphagov/#{repo_name}/contents/.govuk_dependabot_merger.yml" }
-
     it "should return the Dependabot Merger config for the repo" do
       config = <<~EXTERNAL_CONFIG_YAML
         api_version: 1
@@ -75,7 +75,7 @@ RSpec.describe Repo do
 
   describe "#dependabot_pull_requests" do
     it "should return an array of PullRequest objects" do
-      repo_name = "foo"
+      stub_request(:get, external_config_file_api_url).to_return(status: 200, body: "")
       stub_request(:get, "https://api.github.com/repos/alphagov/#{repo_name}/pulls?sort=created&state=open")
         .to_return(status: 200, body: [pull_request_api_response, pull_request_api_response].to_json, headers: { "Content-Type": "application/json" })
 
@@ -85,7 +85,7 @@ RSpec.describe Repo do
     end
 
     it "should filter out any PRs not raised by Dependabot" do
-      repo_name = "foo"
+      stub_request(:get, external_config_file_api_url).to_return(status: 200, body: "")
       non_dependabot_response = pull_request_api_response({ user: { login: "foo" } })
 
       stub_request(:get, "https://api.github.com/repos/alphagov/#{repo_name}/pulls?sort=created&state=open")

--- a/spec/lib/repo_spec.rb
+++ b/spec/lib/repo_spec.rb
@@ -11,6 +11,35 @@ RSpec.describe Repo do
     end
   end
 
+  describe "#govuk_dependabot_merger_config" do
+    let(:repo_name) { "foo" }
+    let(:external_config_file_api_url) { "https://api.github.com/repos/alphagov/#{repo_name}/contents/.govuk_dependabot_merger.yml" }
+
+    it "should return the Dependabot Merger config for the repo" do
+      config = <<~EXTERNAL_CONFIG_YAML
+        api_version: 1
+        auto_merge:
+          - dependency: govuk_publishing_components
+            allowed_semver_bumps:
+              - patch
+              - minor
+      EXTERNAL_CONFIG_YAML
+      stub_request(:get, external_config_file_api_url)
+        .to_return(status: 200, body: config.to_json, headers: { "Content-Type": "application/json" })
+
+      repo = Repo.new(repo_name)
+      expect(repo.govuk_dependabot_merger_config).to eq({
+        "api_version" => 1,
+        "auto_merge" => [
+          {
+            "allowed_semver_bumps" => %w[patch minor],
+            "dependency" => "govuk_publishing_components",
+          },
+        ],
+      })
+    end
+  end
+
   describe "#dependabot_pull_requests" do
     it "should return an array of PullRequest objects" do
       repo_name = "foo"

--- a/spec/lib/repo_spec.rb
+++ b/spec/lib/repo_spec.rb
@@ -61,6 +61,16 @@ RSpec.describe Repo do
         "error" => "syntax",
       })
     end
+
+    it "should return an error hash if the config file is missing" do
+      stub_request(:get, external_config_file_api_url)
+        .to_return(status: 404)
+
+      repo = Repo.new(repo_name)
+      expect(repo.govuk_dependabot_merger_config).to eq({
+        "error" => "404",
+      })
+    end
   end
 
   describe "#dependabot_pull_requests" do


### PR DESCRIPTION
We're currently re-fetching the same repo config for every Dependabot pull request, making lots of unnecessary API calls. We're also currently doing this within `PullRequest`, which makes it harder to test variations of remote config, and means `PullRequest` is doing too much.

This PR moves the logic out of `PullRequest` and into `Repo`, solving both of the above issues.
This also prepares us for making config API changes more easily.

Trello: https://trello.com/c/pOBu4Y90/3452-change-govuk-dependabot-merger-api-5