### PR TITLE
Release V2 (implementing RFC-167)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # GOV.UK Dependabot Merger
 
-This repository runs a daily GitHub action that automatically approves and merges certain Dependabot PRs for opted-in GOV.UK repos, according to [strict criteria set out in RFC-156](https://github.com/alphagov/govuk-rfcs/blob/main/rfc-156-auto-merge-internal-prs.md), summarised below:
+This repository runs a daily GitHub action that automatically approves and merges certain Dependabot PRs for opted-in GOV.UK repos, according to [strict criteria set out in RFC-167](https://github.com/alphagov/govuk-rfcs/blob/main/rfc-167-auto-patch-dependencies.md#conditions-required-for-automatic-patching).
 
-> This service should ONLY be used to merge internal dependencies (excluding 'major' version updates). It should also only be enabled on repos which have sufficient test coverage (such as continuously deployed apps, as these have to reach 95% coverage). Deviate from the guidance at your own risk.
-
-Note that govuk-dependabot-merger will avoid merging a PR if it has a failing GitHub Action CI build called `test-ruby`, [as per convention](https://docs.publishing.service.gov.uk/manual/test-and-build-a-project-with-github-actions.html#branch-protection-rules). It will also avoid running altogether on weekends and bank holidays.
+Note that govuk-dependabot-merger will avoid merging a PR if it has a failing GitHub Action CI workflow called `CI`, [as per convention](https://docs.publishing.service.gov.uk/manual/test-and-build-a-project-with-github-actions.html#branch-protection-rules). It will also avoid running altogether on weekends and bank holidays.
 
 ## Usage
 
@@ -13,16 +11,26 @@ To opt into the govuk-dependabot-merger service, first create a `.govuk_dependab
 For example:
 
 ```yaml
-api_version: 1
-auto_merge:
+api_version: 2
+defaults:
+  update_external_dependencies: false # default: false
+  auto_merge: true # default: true
+  allowed_semver_bumps: # allowed values: `[patch, minor, major]`
+    - patch
+    - minor
+  # The above sets the default policy for all dependencies in your project.
+  # But each of the above properties can be overridden on a per-dependency basis below.
+overrides:
+  # Example of overriding `allowed_semver_bumps`:
+  - dependency: gds-api-adapters
+    allowed_semver_bumps:
+      - patch
+  # Example of opting a specific dependency out of automatic patching:
   - dependency: govuk_publishing_components
-    allowed_semver_bumps:
-      - patch
-      - minor
-  - dependency: rubocop-govuk
-    allowed_semver_bumps:
-      - patch
-      - minor
+    auto_merge: false
+  # Example of opting a specific dependency into automatic patching:
+  - dependency: rspec
+    update_external_dependencies: true
 ```
 
 After you've merged your config file into your main branch, you just need to add your repository to the [config/repos_opted_in.yml](config/repos_opted_in.yml) list in govuk-dependabot-merger.

--- a/lib/auto_merger.rb
+++ b/lib/auto_merger.rb
@@ -25,13 +25,13 @@ module AutoMerger
       policy_manager = PolicyManager.new(repo.govuk_dependabot_merger_config)
 
       if !policy_manager.remote_config_exists?
-        puts "The remote .govuk_dependabot_merger.yml file is missing."
+        puts "#{repo.name}: the remote .govuk_dependabot_merger.yml file is missing."
       elsif !policy_manager.valid_remote_config_syntax?
-        puts "The remote .govuk_dependabot_merger.yml YAML syntax is corrupt."
+        puts "#{repo.name}: the remote .govuk_dependabot_merger.yml YAML syntax is corrupt."
       elsif !policy_manager.remote_config_api_version_supported?
-        puts "The remote .govuk_dependabot_merger.yml file is using an unsupported API version."
+        puts "#{repo.name}: the remote .govuk_dependabot_merger.yml file is using an unsupported API version."
       elsif repo.dependabot_pull_requests.count.zero?
-        puts "No Dependabot PRs found for repo '#{repo.name}'."
+        puts "#{repo.name}: no Dependabot PRs found."
       else
         puts "#{repo.dependabot_pull_requests.count} Dependabot PRs found for repo '#{repo.name}':"
 

--- a/lib/auto_merger.rb
+++ b/lib/auto_merger.rb
@@ -38,24 +38,24 @@ module AutoMerger
         repo.dependabot_pull_requests.each do |pr|
           puts "  - Inspecting #{repo.name}##{pr.number}..."
 
-          merge_dependabot_pr(pr, dry_run:)
+          merge_dependabot_pr(pr, policy_manager, dry_run:)
         end
       end
     end
   end
 
-  def self.merge_dependabot_pr(pull_request, dry_run: true)
-    if pull_request.is_auto_mergeable?
-      if dry_run
-        puts "    ...eligible for auto-merge! This is a dry run, so skipping."
-      else
-        puts "    ...approving! ✅"
-        pull_request.approve!
-        puts "    ...merging! 🎉"
-        pull_request.merge!
-      end
+  def self.merge_dependabot_pr(pull_request, policy_manager, dry_run: true)
+    if !policy_manager.is_auto_mergeable?(pull_request)
+      puts "    ...auto-merging is against policy: #{policy_manager.reasons_not_to_merge(pull_request).join(' ')} Skipping."
+    elsif !pull_request.is_auto_mergeable?
+      puts "    ...auto-merging is allowable in theory, but bad PR: #{pull_request.reasons_not_to_merge.join(' ')} Skipping."
+    elsif dry_run
+      puts "    ...eligible for auto-merge! This is a dry run, so skipping."
     else
-      puts "    ...not auto-mergeable: #{pull_request.reasons_not_to_merge.join(' ')} Skipping."
+      puts "    ...approving! ✅"
+      pull_request.approve!
+      puts "    ...merging! 🎉"
+      pull_request.merge!
     end
   end
 

--- a/lib/policy_manager.rb
+++ b/lib/policy_manager.rb
@@ -12,6 +12,15 @@ class PolicyManager
     determine_allowed_dependencies
   end
 
+  def defaults
+    defaults = @remote_config["defaults"] || {}
+    {
+      update_external_dependencies: defaults["update_external_dependencies"].nil? ? false : defaults["update_external_dependencies"],
+      auto_merge: defaults["auto_merge"].nil? ? true : defaults["auto_merge"],
+      allowed_semver_bumps: defaults["allowed_semver_bumps"].nil? ? %i[patch minor] : defaults["allowed_semver_bumps"],
+    }
+  end
+
   def remote_config_exists?
     @remote_config["error"] != "404"
   end

--- a/lib/policy_manager.rb
+++ b/lib/policy_manager.rb
@@ -70,6 +70,11 @@ class PolicyManager
     reasons_not_to_merge
   end
 
+  def change_allowed?(dependency_name, change_type)
+    policy = dependency_policy(dependency_name)
+    policy[:auto_merge] && policy[:allowed_semver_bumps].include?(change_type)
+  end
+
   def allow_dependency_update(name:, allowed_semver_bumps:)
     allowed_dependency_updates << { name:, allowed_semver_bumps: }
   end

--- a/lib/policy_manager.rb
+++ b/lib/policy_manager.rb
@@ -21,6 +21,22 @@ class PolicyManager
     }
   end
 
+  def dependency_policy(dependency_name)
+    dependency_overrides = @remote_config["overrides"]&.find { |dependency| dependency["dependency"] == dependency_name } || {}
+
+    update_external_dependencies = dependency_overrides["update_external_dependencies"].nil? ? defaults[:update_external_dependencies] : dependency_overrides["update_external_dependencies"]
+    allowed_semver_bumps = dependency_overrides["allowed_semver_bumps"].nil? ? defaults[:allowed_semver_bumps] : dependency_overrides["allowed_semver_bumps"]
+    auto_merge = dependency_overrides["auto_merge"].nil? ? defaults[:auto_merge] : dependency_overrides["auto_merge"]
+
+    dependency = Dependency.new(dependency_name)
+    auto_merge = update_external_dependencies if auto_merge && !dependency.internal?
+
+    {
+      auto_merge:,
+      allowed_semver_bumps: auto_merge ? allowed_semver_bumps : [],
+    }
+  end
+
   def remote_config_exists?
     @remote_config["error"] != "404"
   end

--- a/lib/repo.rb
+++ b/lib/repo.rb
@@ -1,6 +1,5 @@
 require "yaml"
 require_relative "./github_client"
-require_relative "./policy_manager"
 require_relative "./pull_request"
 
 Repo = Struct.new(:name) do
@@ -29,10 +28,10 @@ Repo = Struct.new(:name) do
       .instance
       .pull_requests("alphagov/#{name}", state: :open, sort: :created)
       .select { |api_response| api_response.user.login == "dependabot[bot]" }
-      .map { |api_response| PullRequest.new(api_response, PolicyManager.new(govuk_dependabot_merger_config)) }
+      .map { |api_response| PullRequest.new(api_response) }
   end
 
   def dependabot_pull_request(pr_number)
-    PullRequest.new(GitHubClient.instance.pull_request("alphagov/#{name}", pr_number), PolicyManager.new(govuk_dependabot_merger_config))
+    PullRequest.new(GitHubClient.instance.pull_request("alphagov/#{name}", pr_number))
   end
 end

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module DependabotAutoMerge
-  VERSION = 1
+  VERSION = 2
 end

--- a/spec/lib/auto_merger_spec.rb
+++ b/spec/lib/auto_merger_spec.rb
@@ -6,6 +6,16 @@ RSpec.describe AutoMerger do
     allow($stdout).to receive(:puts) # suppress console output as it gets noisy
   end
 
+  let(:policy_manager) do
+    mock_policy_manager = instance_double("PolicyManager")
+    allow(mock_policy_manager).to receive(:remote_config_exists?).and_return(true)
+    allow(mock_policy_manager).to receive(:valid_remote_config_syntax?).and_return(true)
+    allow(mock_policy_manager).to receive(:remote_config_api_version_supported?).and_return(true)
+    allow(mock_policy_manager).to receive(:is_auto_mergeable?).and_return(true)
+    allow(PolicyManager).to receive(:new).and_return(mock_policy_manager)
+    mock_policy_manager
+  end
+
   describe ".invoke_merge_script!" do
     it "should fail silently if this is a bank holiday" do
       allow(Date).to receive(:bank_holidays).and_return([Date.today])
@@ -32,14 +42,6 @@ RSpec.describe AutoMerger do
   end
 
   describe ".merge_dependabot_prs" do
-    let!(:policy_manager) do
-      mock_policy_manager = instance_double("PolicyManager")
-      allow(mock_policy_manager).to receive(:remote_config_exists?).and_return(true)
-      allow(mock_policy_manager).to receive(:valid_remote_config_syntax?).and_return(true)
-      allow(mock_policy_manager).to receive(:remote_config_api_version_supported?).and_return(true)
-      allow(PolicyManager).to receive(:new).and_return(mock_policy_manager)
-      mock_policy_manager
-    end
     let(:mock_pr) do
       instance_double("PullRequest", number: 1, is_auto_mergeable?: true, approve!: true, merge!: true)
     end
@@ -55,9 +57,9 @@ RSpec.describe AutoMerger do
         mock_repo_2,
       ])
 
-      expect(AutoMerger).to receive(:merge_dependabot_pr).with(mock_pr_1, dry_run: false)
-      expect(AutoMerger).to receive(:merge_dependabot_pr).with(mock_pr_2, dry_run: false)
-      expect(AutoMerger).to receive(:merge_dependabot_pr).with(mock_pr_3, dry_run: false)
+      expect(AutoMerger).to receive(:merge_dependabot_pr).with(mock_pr_1, policy_manager, dry_run: false)
+      expect(AutoMerger).to receive(:merge_dependabot_pr).with(mock_pr_2, policy_manager, dry_run: false)
+      expect(AutoMerger).to receive(:merge_dependabot_pr).with(mock_pr_3, policy_manager, dry_run: false)
 
       AutoMerger.merge_dependabot_prs
     end
@@ -67,7 +69,7 @@ RSpec.describe AutoMerger do
       mock_repo = instance_double("Repo", name: "Repo", govuk_dependabot_merger_config: {}, dependabot_pull_requests: [mock_pr])
       allow(Repo).to receive(:all).and_return([mock_repo])
 
-      expect(AutoMerger).to receive(:merge_dependabot_pr).with(mock_pr, dry_run: true)
+      expect(AutoMerger).to receive(:merge_dependabot_pr).with(mock_pr, policy_manager, dry_run: true)
 
       AutoMerger.merge_dependabot_prs(dry_run: true)
     end
@@ -116,22 +118,46 @@ RSpec.describe AutoMerger do
   end
 
   describe ".merge_dependabot_pr" do
-    it "avoids approving or merging when in dry run mode" do
+    let(:mock_pr) do
       mock_pr = instance_double("PullRequest")
       allow(mock_pr).to receive(:is_auto_mergeable?).and_return(true)
+      mock_pr
+    end
 
+    def expect_no_merge(mock_pr)
       expect(mock_pr).to_not receive(:approve!)
       expect(mock_pr).to_not receive(:merge!)
-      AutoMerger.merge_dependabot_pr(mock_pr, dry_run: true)
+    end
+
+    it "should make a call to PolicyManager.is_auto_mergeable?, which should block merge if false" do
+      allow(policy_manager).to receive(:is_auto_mergeable?).and_return(false)
+      allow(policy_manager).to receive(:reasons_not_to_merge).and_return(["Foo."])
+
+      expect_no_merge(mock_pr)
+      expect { AutoMerger.merge_dependabot_pr(mock_pr, policy_manager, dry_run: false) }.to output(
+        "    ...auto-merging is against policy: Foo. Skipping.\n",
+      ).to_stdout
+    end
+
+    it "should make a call to PullRequest's `is_auto_mergeable?`, which should block merge if false" do
+      allow(mock_pr).to receive(:is_auto_mergeable?).and_return(false)
+      allow(mock_pr).to receive(:reasons_not_to_merge).and_return(["Bar."])
+
+      expect_no_merge(mock_pr)
+      expect { AutoMerger.merge_dependabot_pr(mock_pr, policy_manager, dry_run: false) }.to output(
+        "    ...auto-merging is allowable in theory, but bad PR: Bar. Skipping.\n",
+      ).to_stdout
+    end
+
+    it "avoids approving or merging when in dry run mode" do
+      expect_no_merge(mock_pr)
+      AutoMerger.merge_dependabot_pr(mock_pr, policy_manager, dry_run: true)
     end
 
     it "calls approve! and merge! when not in dry run mode" do
-      mock_pr = instance_double("PullRequest")
-      allow(mock_pr).to receive(:is_auto_mergeable?).and_return(true)
-
       expect(mock_pr).to receive(:approve!)
       expect(mock_pr).to receive(:merge!)
-      AutoMerger.merge_dependabot_pr(mock_pr, dry_run: false)
+      AutoMerger.merge_dependabot_pr(mock_pr, policy_manager, dry_run: false)
     end
   end
 

--- a/spec/lib/auto_merger_spec.rb
+++ b/spec/lib/auto_merger_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe AutoMerger do
 
       expect(policy_manager).to receive(:remote_config_exists?)
       expect(AutoMerger).to_not receive(:merge_dependabot_pr)
-      expect { AutoMerger.merge_dependabot_prs }.to output("The remote .govuk_dependabot_merger.yml file is missing.\n").to_stdout
+      expect { AutoMerger.merge_dependabot_prs }.to output("Repo 1: the remote .govuk_dependabot_merger.yml file is missing.\n").to_stdout
     end
 
     it "should make a call to PolicyManager.valid_remote_config_syntax?, which should block merge if false" do
@@ -91,7 +91,7 @@ RSpec.describe AutoMerger do
 
       expect(policy_manager).to receive(:valid_remote_config_syntax?)
       expect(AutoMerger).to_not receive(:merge_dependabot_pr)
-      expect { AutoMerger.merge_dependabot_prs }.to output("The remote .govuk_dependabot_merger.yml YAML syntax is corrupt.\n").to_stdout
+      expect { AutoMerger.merge_dependabot_prs }.to output("Repo 1: the remote .govuk_dependabot_merger.yml YAML syntax is corrupt.\n").to_stdout
     end
 
     it "should make a call to PolicyManager.remote_config_api_version_supported?, which should block merge if false" do
@@ -102,7 +102,16 @@ RSpec.describe AutoMerger do
 
       expect(policy_manager).to receive(:remote_config_api_version_supported?)
       expect(AutoMerger).to_not receive(:merge_dependabot_pr)
-      expect { AutoMerger.merge_dependabot_prs }.to output("The remote .govuk_dependabot_merger.yml file is using an unsupported API version.\n").to_stdout
+      expect { AutoMerger.merge_dependabot_prs }.to output("Repo 1: the remote .govuk_dependabot_merger.yml file is using an unsupported API version.\n").to_stdout
+    end
+
+    it "should announce when no Dependabot PRs were found" do
+      policy_manager # set up the mock policy manager object
+      mock_repo = instance_double("Repo", name: "Repo 1", govuk_dependabot_merger_config: {}, dependabot_pull_requests: [])
+      allow(Repo).to receive(:all).and_return([mock_repo])
+
+      expect(AutoMerger).to_not receive(:merge_dependabot_pr)
+      expect { AutoMerger.merge_dependabot_prs }.to output("Repo 1: no Dependabot PRs found.\n").to_stdout
     end
   end
 

--- a/spec/lib/policy_manager_spec.rb
+++ b/spec/lib/policy_manager_spec.rb
@@ -228,6 +228,26 @@ RSpec.describe PolicyManager do
     end
   end
 
+  describe "#change_allowed?" do
+    it "returns false if `auto_merge` is false" do
+      policy_manager = PolicyManager.new
+      allow(policy_manager).to receive(:dependency_policy).and_return(auto_merge: false)
+      expect(policy_manager.change_allowed?("foo", :patch)).to eq(false)
+    end
+
+    it "returns false if the requested semver isn't allowed" do
+      policy_manager = PolicyManager.new
+      allow(policy_manager).to receive(:dependency_policy).and_return(auto_merge: true, allowed_semver_bumps: %i[patch])
+      expect(policy_manager.change_allowed?("foo", :minor)).to eq(false)
+    end
+
+    it "returns true if both `auto_merge: true` and requested semver is allowed" do
+      policy_manager = PolicyManager.new
+      allow(policy_manager).to receive(:dependency_policy).and_return(auto_merge: true, allowed_semver_bumps: %i[patch])
+      expect(policy_manager.change_allowed?("foo", :patch)).to eq(true)
+    end
+  end
+
   describe "#remote_config_exists?" do
     it "returns false if config doesn't exist" do
       remote_config = { "error" => "404" }

--- a/spec/lib/policy_manager_spec.rb
+++ b/spec/lib/policy_manager_spec.rb
@@ -2,6 +2,31 @@ require_relative "../../lib/policy_manager"
 require_relative "../../lib/version"
 
 RSpec.describe PolicyManager do
+  describe "#defaults" do
+    it "returns set of default behaviours" do
+      expect(PolicyManager.new.defaults).to eq({
+        update_external_dependencies: false,
+        auto_merge: true,
+        allowed_semver_bumps: %i[patch minor],
+      })
+    end
+
+    it "can override the default `update_external_dependencies` property via remote config" do
+      remote_config = { "defaults" => { "update_external_dependencies" => true } }
+      expect(PolicyManager.new(remote_config).defaults[:update_external_dependencies]).to eq(true)
+    end
+
+    it "can override the default `auto_merge` property via remote config" do
+      remote_config = { "defaults" => { "auto_merge" => false } }
+      expect(PolicyManager.new(remote_config).defaults[:auto_merge]).to eq(false)
+    end
+
+    it "can override the default `allowed_semver_bumps` property via remote config" do
+      remote_config = { "defaults" => { "allowed_semver_bumps" => %i[major] } }
+      expect(PolicyManager.new(remote_config).defaults[:allowed_semver_bumps]).to eq(%i[major])
+    end
+  end
+
   describe "#allowed_dependency_updates" do
     it "returns array of dependencies and semvers that are 'allowed' to be auto-merged" do
       manager = PolicyManager.new

--- a/spec/lib/pull_request_spec.rb
+++ b/spec/lib/pull_request_spec.rb
@@ -104,13 +104,7 @@ RSpec.describe PullRequest do
 
   describe "#is_auto_mergeable?" do
     def create_pull_request_instance
-      mock = instance_double("PolicyManager")
-      allow(mock).to receive(:change_set=)
-      allow(mock).to receive(:all_proposed_dependencies_on_allowlist?).and_return(true)
-      allow(mock).to receive(:all_proposed_updates_semver_allowed?).and_return(true)
-      allow(mock).to receive(:all_proposed_dependencies_are_internal?).and_return(true)
-
-      pr = PullRequest.new(pull_request_api_response, mock)
+      pr = PullRequest.new(pull_request_api_response)
       allow(pr).to receive(:validate_single_commit).and_return(true)
       allow(pr).to receive(:validate_files_changed).and_return(true)
       pr
@@ -133,48 +127,6 @@ RSpec.describe PullRequest do
       pr.is_auto_mergeable?
       expect(pr.reasons_not_to_merge).to eq([
         "PR changes files that should not be changed.",
-      ])
-    end
-
-    it "should make a call to PolicyManager.all_proposed_dependencies_on_allowlist?" do
-      stub_successful_check_run
-      stub_remote_commit(head_commit_api_response)
-
-      pr = create_pull_request_instance
-      allow(pr.policy_manager).to receive(:all_proposed_dependencies_on_allowlist?).and_return(false)
-      expect(pr.policy_manager).to receive(:all_proposed_dependencies_on_allowlist?)
-
-      pr.is_auto_mergeable?
-      expect(pr.reasons_not_to_merge).to eq([
-        "PR bumps a dependency that is not on the allowlist.",
-      ])
-    end
-
-    it "should make a call to PolicyManager.all_proposed_updates_semver_allowed?" do
-      stub_successful_check_run
-      stub_remote_commit(head_commit_api_response)
-
-      pr = create_pull_request_instance
-      allow(pr.policy_manager).to receive(:all_proposed_updates_semver_allowed?).and_return(false)
-      expect(pr.policy_manager).to receive(:all_proposed_updates_semver_allowed?)
-
-      pr.is_auto_mergeable?
-      expect(pr.reasons_not_to_merge).to eq([
-        "PR bumps a dependency to a higher semver than is allowed.",
-      ])
-    end
-
-    it "should make a call to PolicyManager.all_proposed_dependencies_are_internal?" do
-      stub_successful_check_run
-      stub_remote_commit(head_commit_api_response)
-
-      pr = create_pull_request_instance
-      allow(pr.policy_manager).to receive(:all_proposed_dependencies_are_internal?).and_return(false)
-      expect(pr.policy_manager).to receive(:all_proposed_dependencies_are_internal?)
-
-      pr.is_auto_mergeable?
-      expect(pr.reasons_not_to_merge).to eq([
-        "PR bumps an external dependency.",
       ])
     end
 


### PR DESCRIPTION
This PR implements [RFC-167](https://github.com/alphagov/govuk-rfcs/blob/main/rfc-167-auto-patch-dependencies.md), which allows for automatic patching of _external_ dependencies as well as internal ones. 🎉  The resulting API is much more configurable.

## Upgrade guide

Teams will need to update their `.govuk_dependabot_merger.yml` files to V2 to continue to use govuk-dependabot-merger. Teams who don't upgrade will see "#{repo_name}: the remote .govuk_dependabot_merger.yml file is using an unsupported API version." in the ["Merge Dependabot PRs" logs](https://github.com/alphagov/govuk-dependabot-merger/actions/workflows/merge-dependabot-prs.yml)

Breaking changes:

- `api_version` must be changed from 1 to 2
- `auto_merge` is no longer a recognised key
- `defaults` and `overrides` are both optional keys, which can be used to configure the govuk-dependabot-merger service per-repo and per-dependency.

Various example configurations are explained in https://github.com/alphagov/govuk-rfcs/blob/main/rfc-167-auto-patch-dependencies.md#examples-govuk-dependabot-merger-configs. TLDR:

If you're wanting to retain the old, allowlist-only behaviour, it would look something like:

```yaml
api_version: 2
defaults:
  auto_merge: false
overrides:
  - dependency: rubocop-govuk
    auto_merge: true
  - dependency: govuk_app_config
    auto_merge: true
  # etc...
```

If you're wanting to auto-merge all internal dependencies, but not external dependencies, the config is simply:

```yaml
api_version: 2
defaults:
  auto_merge: true
```

If you're wanting to auto-merge all dependencies, including external dependencies, the config is as follows - but remember, [RFC-167 stipulates that minimum test coverage and security scans are in place](https://github.com/alphagov/govuk-rfcs/blob/main/rfc-167-auto-patch-dependencies.md#conditions-required-for-automatic-patching) first:

```yaml
api_version: 2
defaults:
  auto_merge: true
  update_external_dependencies: true
```

You can opt in, or opt out, specific dependencies using the `overrides` array and setting `auto_merge` / `update_external_dependencies` accordingly. You can also override which semver sizes are considered auto-mergeable, though as a reminder, [RFC-167 stipulates that 'major' version increases should not be auto-merged](https://github.com/alphagov/govuk-rfcs/blob/main/rfc-167-auto-patch-dependencies.md#version-increase-is-patch-or-minor).

---

Trello: https://trello.com/c/pOBu4Y90/3452-change-govuk-dependabot-merger-api-5