### PR TITLE
Catch exception when Rubygem does not exist

### DIFF
--- a/lib/change_set.rb
+++ b/lib/change_set.rb
@@ -3,6 +3,9 @@ Dependency = Struct.new(:name) do
     Net::HTTP.get(URI("https://rubygems.org/api/v1/gems/#{name}/owners.yaml"))
       .then { |response| YAML.safe_load response }
       .any? { |owner| owner["handle"] == "govuk" }
+  rescue NoMethodError
+    puts "This rubygem could not be found."
+    false
   end
 end
 

--- a/spec/lib/change_set_spec.rb
+++ b/spec/lib/change_set_spec.rb
@@ -25,6 +25,15 @@ RSpec.describe Dependency do
 
       expect(Dependency.new("foo").internal?).to eq(false)
     end
+
+    it "returns false if the dependency is not found in Rubygems" do
+      stub_request(:get, "https://rubygems.org/api/v1/gems/foo/owners.yaml")
+      .to_return(
+        body: "This rubygem could not be found.",
+      )
+
+      expect(Dependency.new("foo").internal?).to eq(false)
+    end
   end
 end
 


### PR DESCRIPTION
This should fix errors such as:
```
/home/runner/work/govuk-dependabot-merger/govuk-dependabot-merger/lib/change_set.rb:5:in `internal?': undefined method `any?' for an instance of String (NoMethodError)
      .any? { |owner| owner["handle"] == "govuk" }
```