### PR TITLE
Fix multiple commits edge case

### DIFF
--- a/lib/auto_merger.rb
+++ b/lib/auto_merger.rb
@@ -45,10 +45,10 @@ module AutoMerger
   end
 
   def self.merge_dependabot_pr(pull_request, policy_manager, dry_run: true)
-    if !policy_manager.is_auto_mergeable?(pull_request)
+    if !pull_request.is_auto_mergeable?
+      puts "    ...bad PR: #{pull_request.reasons_not_to_merge.join(' ')} Skipping."
+    elsif !policy_manager.is_auto_mergeable?(pull_request)
       puts "    ...auto-merging is against policy: #{policy_manager.reasons_not_to_merge(pull_request).join(' ')} Skipping."
-    elsif !pull_request.is_auto_mergeable?
-      puts "    ...auto-merging is allowable in theory, but bad PR: #{pull_request.reasons_not_to_merge.join(' ')} Skipping."
     elsif dry_run
       puts "    ...eligible for auto-merge! This is a dry run, so skipping."
     else

--- a/spec/lib/auto_merger_spec.rb
+++ b/spec/lib/auto_merger_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe AutoMerger do
 
       expect_no_merge(mock_pr)
       expect { AutoMerger.merge_dependabot_pr(mock_pr, policy_manager, dry_run: false) }.to output(
-        "    ...auto-merging is allowable in theory, but bad PR: Bar. Skipping.\n",
+        "    ...bad PR: Bar. Skipping.\n",
       ).to_stdout
     end
 


### PR DESCRIPTION
Adding a commit to a Dependabot PR triggered an error where it expected a commit message in a Dependabot format. It should not proceed if there are multiple commits.

[Trello](https://trello.com/c/lPzO7C69/3504-dependabot-merger-fixes)