### PR TITLE
Fix `allowed_semver_bumps` config option

### DIFF
--- a/lib/policy_manager.rb
+++ b/lib/policy_manager.rb
@@ -27,7 +27,7 @@ class PolicyManager
 
     {
       auto_merge:,
-      allowed_semver_bumps: auto_merge ? allowed_semver_bumps : [],
+      allowed_semver_bumps: auto_merge ? allowed_semver_bumps.map(&:to_sym) : [],
     }
   end
 

--- a/spec/lib/policy_manager_spec.rb
+++ b/spec/lib/policy_manager_spec.rb
@@ -178,6 +178,24 @@ RSpec.describe PolicyManager do
           allowed_semver_bumps:,
         })
       end
+
+      it "converts default allowed_semver_bumps to symbols" do
+        remote_config["defaults"]["allowed_semver_bumps"] = %w[patch minor]
+
+        expect(policy_manager.dependency_policy(external_dependency)).to eq({
+          auto_merge: true,
+          allowed_semver_bumps: %i[patch minor],
+        })
+      end
+
+      it "converts overridden allowed_semver_bumps to symbols" do
+        remote_config["overrides"] = [{ "dependency" => external_dependency, "allowed_semver_bumps" => %w[patch] }]
+
+        expect(policy_manager.dependency_policy(external_dependency)).to eq({
+          auto_merge: true,
+          allowed_semver_bumps: %i[patch],
+        })
+      end
     end
   end
 


### PR DESCRIPTION
These were being treated as arrays of strings, rather than arrays of symbols, meaning the `change_allowed?` method of PolicyManager would always return `false` even if the dependency update is of the correct semver 'size'.

We now cast the config option to an array of symbols at the point of use, which fixes the issue.