### PR TITLE
Allow changes to yarn.lock files

### DIFF
--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -40,8 +40,8 @@ class PullRequest
   def validate_files_changed
     commit = GitHubClient.instance.commit("alphagov/#{@api_response.base.repo.name}", @api_response.head.sha)
     files_changed = commit.files.map(&:filename)
-    # TODO: support other package managers too (e.g. NPM)
-    files_changed == ["Gemfile.lock"]
+    allowed_files = ["yarn.lock", "Gemfile.lock"]
+    (files_changed - allowed_files).empty?
   end
 
   def validate_ci_workflow_exists

--- a/spec/lib/pull_request_spec.rb
+++ b/spec/lib/pull_request_spec.rb
@@ -201,6 +201,14 @@ RSpec.describe PullRequest do
       expect(pr.validate_files_changed).to eq(true)
     end
 
+    it "returns true if PR only changes yarn.lock" do
+      head_commit_api_response[:files][0][:filename] = "yarn.lock"
+      stub_remote_commit(head_commit_api_response)
+
+      pr = PullRequest.new(pull_request_api_response)
+      expect(pr.validate_files_changed).to eq(true)
+    end
+
     it "returns false if PR changes anything else" do
       head_commit_api_response[:files][0][:filename] = "something_else.rb"
       stub_remote_commit(head_commit_api_response)


### PR DESCRIPTION
This will allow some Javascript dependencies to be automatically merged.

Example of PR that would be affected by this change: https://github.com/alphagov/travel-advice-publisher/pull/1890

I have not added `Gemfile` and `package.json` to the allowed files list because in some cases we may have legitimate reasons to keep dependencies pinned to specific versions and we don't want Dependabot to change that.