### PR TITLE
Fix error on unexpected commit message

### DIFF
--- a/lib/change_set.rb
+++ b/lib/change_set.rb
@@ -9,6 +9,8 @@ Dependency = Struct.new(:name) do
   end
 end
 
+class UnexpectedCommitMessage < StandardError; end
+
 Change = Struct.new(:dependency, :type) do
   def self.type_from_dependabot_type(dependabot_type)
     case dependabot_type
@@ -21,7 +23,7 @@ Change = Struct.new(:dependency, :type) do
     else
       # As of March 2024, these are the only options Dependabot can return
       # If they add more in the future, we will need to update this
-      raise "Unrecognised update-type: #{dependabot_type}"
+      raise(UnexpectedCommitMessage, "Unrecognised update-type: #{dependabot_type}")
     end
   end
 end
@@ -47,6 +49,6 @@ class ChangeSet
       }
       .then { |changes| ChangeSet.new changes }
   rescue StandardError
-    raise "Commit message is not in the expected format"
+    raise(UnexpectedCommitMessage, "Commit message is not in the expected format")
   end
 end

--- a/lib/policy_manager.rb
+++ b/lib/policy_manager.rb
@@ -58,6 +58,8 @@ class PolicyManager
     end
 
     reasons_not_to_merge
+  rescue UnexpectedCommitMessage => e
+    [e.message]
   end
 
   def change_allowed?(dependency_name, change_type)

--- a/spec/lib/change_set_spec.rb
+++ b/spec/lib/change_set_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Change do
       expect(Change.type_from_dependabot_type("version-update:semver-major")).to eq(:major)
       expect(Change.type_from_dependabot_type("version-update:semver-minor")).to eq(:minor)
       expect(Change.type_from_dependabot_type("version-update:semver-patch")).to eq(:patch)
-      expect { Change.type_from_dependabot_type("foo") }.to raise_error(RuntimeError, "Unrecognised update-type: foo")
+      expect { Change.type_from_dependabot_type("foo") }.to raise_error(UnexpectedCommitMessage, "Unrecognised update-type: foo")
     end
   end
 end
@@ -124,11 +124,11 @@ RSpec.describe ChangeSet do
     it "raises an error if the commit message is not in the expected format" do
       expect {
         ChangeSet.from_commit_message("Hello world!")
-      }.to raise_error(RuntimeError, "Commit message is not in the expected format")
+      }.to raise_error(UnexpectedCommitMessage, "Commit message is not in the expected format")
 
       expect {
         ChangeSet.from_commit_message("foo\n---\nsyntax: error:\n...\nbar")
-      }.to raise_error(RuntimeError, "Commit message is not in the expected format")
+      }.to raise_error(UnexpectedCommitMessage, "Commit message is not in the expected format")
     end
   end
 end

--- a/spec/lib/policy_manager_spec.rb
+++ b/spec/lib/policy_manager_spec.rb
@@ -343,6 +343,23 @@ RSpec.describe PolicyManager do
       ])
     end
 
+    it "should return reasons not to merge when commit message is not in the expected format" do
+      mock_pr = instance_double("PullRequest")
+      allow(mock_pr).to receive(:commit_message).and_return(
+        <<~COMMIT_MESSAGE,
+          ---
+          updated-dependencies:
+          - dependency-name: #{external_dependency}
+            dependency-type: direct:production
+        COMMIT_MESSAGE
+      )
+
+      expect(PolicyManager.new(remote_config).is_auto_mergeable?(mock_pr)).to eq(false)
+      expect(PolicyManager.new(remote_config).reasons_not_to_merge(mock_pr)).to eq([
+        "Commit message is not in the expected format",
+      ])
+    end
+
     it "should return empty array if nothing wrong" do
       mock_pr = instance_double("PullRequest")
       allow(mock_pr).to receive(:commit_message).and_return(


### PR DESCRIPTION
This will catch cases such as [this PR](https://github.com/alphagov/account-api/pull/874/commits) which does not have an `update-type` in its commit message.

It should fix this [error](https://github.com/alphagov/govuk-dependabot-merger/actions/runs/9076260160/job/24938576603)