### PR TITLE
Add special-route-publisher

### DIFF
--- a/config/repos_opted_in.yml
+++ b/config/repos_opted_in.yml
@@ -60,6 +60,7 @@
 - signon
 - siteimprove_api_client
 - smart-answers
+- special-route-publisher
 - specialist-publisher
 - support
 - support-api


### PR DESCRIPTION
Config was added in https://github.com/alphagov/special-route-publisher/pull/322

(Thanks for the reminder, Aga!)