### PR TITLE
Determine update type when it's missing from commit message

### DIFF
--- a/lib/change_set.rb
+++ b/lib/change_set.rb
@@ -26,6 +26,31 @@ Change = Struct.new(:dependency, :type) do
       raise(UnexpectedCommitMessage, "Unrecognised update-type: #{dependabot_type}")
     end
   end
+
+  def self.extract_commit_info(commit_title)
+    # Exclude range conditions
+    return nil if commit_title.match?(/>=\s*\d+\.\d+(?:\.\d+)?\s*,\s*<\s*\d+\.\d+(?:\.\d+)?/)
+
+    match = commit_title.match(/(?:[>=~]*\s*)(\d+\.\d+(?:\.\d+)?(?:-[\w.]+)?) to (?:[>=~]*\s*)(\d+\.\d+(?:\.\d+)?(?:-[\w.]+)?)/)
+
+    return nil unless match
+
+    { from_version: match[1], to_version: match[2] }
+  end
+
+  def self.determine_update_type(from_version, to_version)
+    return nil unless Gem::Version.correct?(from_version) && Gem::Version.correct?(to_version)
+
+    diff_index = Gem::Version.new(to_version).segments.zip(Gem::Version.new(from_version).segments).index { |a, b| a != b }
+    return nil if diff_index.nil?
+
+    %i[major minor patch][diff_index]
+  end
+
+  def self.update_type(commit_message)
+    versions = extract_commit_info(commit_message.lines.first)
+    determine_update_type(versions[:from_version], versions[:to_version])
+  end
 end
 
 class ChangeSet
@@ -36,15 +61,15 @@ class ChangeSet
   end
 
   def self.from_commit_message(commit_message)
-    commit_message = commit_message
+    dependencies = commit_message
       .split("---", 2)[1]
       .split("...", 2)[0]
 
-    YAML.safe_load(commit_message)
+    YAML.safe_load(dependencies)
       .fetch("updated-dependencies")
       .map { |dep|
         dependency = Dependency.new(dep["dependency-name"])
-        type = Change.type_from_dependabot_type(dep["update-type"])
+        type = dep["update-type"].nil? ? Change.update_type(commit_message) : Change.type_from_dependabot_type(dep["update-type"])
         Change.new(dependency, type)
       }
       .then { |changes| ChangeSet.new changes }


### PR DESCRIPTION
Sometimes Dependabot will not include an `update-type` in its commit message: https://github.com/alphagov/rubocop-govuk/pull/401/commits/85a52441901ccb0dba5ce76d5f7f720def7a0cce

In those cases we have to determine it ourselves by analysing the commit title.

https://trello.com/c/FrDg6Ch1/3582-make-dependabot-merger-calculate-the-update-type-if-its-missing-3