### PR TITLE
Update example for Rails dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,18 +22,16 @@ defaults:
   # But each of the above properties can be overridden on a per-dependency basis below.
 overrides:
   # Example of overriding `allowed_semver_bumps`:
-  - dependency: gds-api-adapters
+  - dependency: rails
     allowed_semver_bumps:
-      - patch
+      - patch # minor/major bumps should be upgraded manually. See https://docs.publishing.service.gov.uk/manual/keeping-software-current.html#rails
   # Example of opting a specific dependency out of automatic patching:
-  - dependency: rails # should be upgraded manually, see https://docs.publishing.service.gov.uk/manual/keeping-software-current.html#rails
+  - dependency: gds-api-adapters
     auto_merge: false
   # Example of opting a specific dependency into automatic patching:
   - dependency: rspec
     update_external_dependencies: true
 ```
-
-> We generally [advise taking extra care with Rails upgrades](https://docs.publishing.service.gov.uk/manual/keeping-software-current.html#rails) therefore those upgrades shouldn't be auto-merged.
 
 After you've merged your config file into your main branch, you just need to add your repository to the [config/repos_opted_in.yml](config/repos_opted_in.yml) list in govuk-dependabot-merger.
 


### PR DESCRIPTION
Rails patch updates are fine to merge.

Trello: https://trello.com/c/AlWoQfl0/2859-allow-auto-merging-of-patch-versions-of-rails