### PR TITLE
Remove special-route-publisher (now retired)

### DIFF
--- a/config/repos_opted_in.yml
+++ b/config/repos_opted_in.yml
@@ -62,7 +62,6 @@
 - signon
 - siteimprove_api_client
 - smart-answers
-- special-route-publisher
 - specialist-publisher
 - support
 - support-api


### PR DESCRIPTION
https://github.com/alphagov/special-route-publisher/pull/353

https://trello.com/c/9rOxWNnD/396-retire-special-route-publisher