### PR TITLE
Allow changes to Gemfile

### DIFF
--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -40,7 +40,7 @@ class PullRequest
   def validate_files_changed
     commit = GitHubClient.instance.commit("alphagov/#{@api_response.base.repo.name}", @api_response.head.sha)
     files_changed = commit.files.map(&:filename)
-    allowed_files = ["yarn.lock", "Gemfile.lock", "#{@api_response.base.repo.name}.gemspec"]
+    allowed_files = ["yarn.lock", "Gemfile.lock", "Gemfile", "#{@api_response.base.repo.name}.gemspec"]
     (files_changed - allowed_files).empty?
   end
 

--- a/spec/lib/pull_request_spec.rb
+++ b/spec/lib/pull_request_spec.rb
@@ -201,6 +201,16 @@ RSpec.describe PullRequest do
       expect(pr.validate_files_changed).to eq(true)
     end
 
+    it "returns true if PR changes Gemfile and Gemfile.lock" do
+      gemfile = head_commit_api_response[:files].first.dup
+      gemfile[:filename] = "Gemfile"
+      head_commit_api_response[:files] << gemfile
+      stub_remote_commit(head_commit_api_response)
+
+      pr = PullRequest.new(pull_request_api_response)
+      expect(pr.validate_files_changed).to eq(true)
+    end
+
     it "returns true if PR only changes yarn.lock" do
       head_commit_api_response[:files][0][:filename] = "yarn.lock"
       stub_remote_commit(head_commit_api_response)


### PR DESCRIPTION
Fixes #83

Rails upgrades that have been configured to auto-merge fail because they touch the `Gemfile`:

```
 - Inspecting whitehall#9528...
    ...bad PR: PR changes files that should not be changed. Skipping.
```

I would argue that tweaks to the Gemfile are allowable.