### PR TITLE
Allow changes to package.json

### DIFF
--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -40,7 +40,7 @@ class PullRequest
   def validate_files_changed
     commit = GitHubClient.instance.commit("alphagov/#{@api_response.base.repo.name}", @api_response.head.sha)
     files_changed = commit.files.map(&:filename)
-    allowed_files = ["yarn.lock", "Gemfile.lock", "Gemfile", "#{@api_response.base.repo.name}.gemspec"]
+    allowed_files = ["yarn.lock", "package.json", "Gemfile.lock", "Gemfile", "#{@api_response.base.repo.name}.gemspec"]
     (files_changed - allowed_files).empty?
   end
 

--- a/spec/lib/pull_request_spec.rb
+++ b/spec/lib/pull_request_spec.rb
@@ -219,6 +219,16 @@ RSpec.describe PullRequest do
       expect(pr.validate_files_changed).to eq(true)
     end
 
+    it "returns true if PR changes package.json" do
+      pkg_json = head_commit_api_response[:files].first.dup
+      pkg_json[:filename] = "package.json"
+      head_commit_api_response[:files] << pkg_json
+      stub_remote_commit(head_commit_api_response)
+
+      pr = PullRequest.new(pull_request_api_response)
+      expect(pr.validate_files_changed).to eq(true)
+    end
+
     it "returns false if PR changes anything else" do
       head_commit_api_response[:files][0][:filename] = "something_else.rb"
       stub_remote_commit(head_commit_api_response)


### PR DESCRIPTION
There are plenty of harmless Dependabot PRs which are currently not auto-merged because they make changes to the `package.json` file, which we have not yet configured to allow.
Example PR:
https://github.com/alphagov/travel-advice-publisher/pull/2018

This commit adds that configuration. Similar to the work added in #84 (which allowed edits to the `Gemfile`), this config tweak should be safe because:

- CI should continue to catch any breaking change (and prevent auto merge)
- Developers can explicitly opt out sensitive repos from auto merge, using the govuk_dependabot_merger.yml config file).
- Additionally, devs can configure their dependabot.yml to [specify a versioning-strategy](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#versioning-strategy) if they wish Dependabot to only raise PRs that bump the lockfile (`lockfile-only` strategy) and ignore any updates that would require edits to `package.json`.

This should remove a large proportion of the remaining toil associated with Dependabot updates. Fixes #85.

Trello: https://trello.com/c/DMqKVRxT/3026-tweak-govuk-dependabot-merger-to-allow-auto-merging-of-prs-that-edit-packagejson