### PR TITLE
Add `govuk-graphql` to repos opted into automatic merges

### DIFF
--- a/config/repos_opted_in.yml
+++ b/config/repos_opted_in.yml
@@ -36,6 +36,7 @@
 - govuk-dependency-checker
 - govuk-developer-docs
 - govuk-docker
+- govuk-graphql
 - govuk-rota-announcer
 - govuk-rota-generator
 - govuk-saas-config


### PR DESCRIPTION
This is a new repo being used for experimental work, but has dependabot set up, so we should automatically merge dependabot updates to reduce manual work needed by the Publishing Platform team.