### PR TITLE
Remove `govuk-sli-collector`

### DIFF
--- a/config/repos_opted_in.yml
+++ b/config/repos_opted_in.yml
@@ -40,7 +40,6 @@
 - govuk-rota-announcer
 - govuk-rota-generator
 - govuk-saas-config
-- govuk-sli-collector
 - govuk-user-reviewer
 - hmrc-manuals-api
 - link-checker-api


### PR DESCRIPTION
This application is no longer used and the repo has been archived, so we no longer need to merge dependabot PRs.

[Trello card](https://trello.com/c/YV6VNRFO)