### PR TITLE
Report Dependabot Merger run failures to Slack

### DIFF
--- a/.github/workflows/merge-dependabot-prs.yml
+++ b/.github/workflows/merge-dependabot-prs.yml
@@ -23,3 +23,10 @@ jobs:
           AUTO_MERGE_TOKEN: ${{ secrets.AUTO_MERGE_TOKEN }}
         run: |
           bundle exec ruby bin/merge_dependabot_prs.rb
+
+      - name: Report GitHub workflow run failure to Slack
+        if: ${{ failure() }}
+        uses: alphagov/govuk-infrastructure/.github/actions/report-run-failure@main
+        with:
+          slack_webhook_url: ${{ secrets.GOVUK_SLACK_WEBHOOK_URL }}
+          channel: govuk-platform-support


### PR DESCRIPTION
We want to be notified so we can investigate the issue or re-run to save developers' time.

Test run: https://github.com/alphagov/govuk-dependabot-merger/actions/runs/14081492307 (workflow is working as expected with the added action)
<img width="774" alt="Screenshot 2025-03-26 at 10 55 02" src="https://github.com/user-attachments/assets/a2917c0e-61e1-4140-ac24-152eaa6dd46e" />
