### PR TITLE
Hotfix: Temporally disable automatic JS dependencies upgrades

### DIFF
--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -40,7 +40,7 @@ class PullRequest
   def validate_files_changed
     commit = GitHubClient.instance.commit("alphagov/#{@api_response.base.repo.name}", @api_response.head.sha)
     files_changed = commit.files.map(&:filename)
-    allowed_files = ["yarn.lock", "package.json", "Gemfile.lock", "Gemfile", "#{@api_response.base.repo.name}.gemspec"]
+    allowed_files = ["Gemfile.lock", "Gemfile", "#{@api_response.base.repo.name}.gemspec"]
     (files_changed - allowed_files).empty?
   end
 

--- a/spec/lib/pull_request_spec.rb
+++ b/spec/lib/pull_request_spec.rb
@@ -211,22 +211,22 @@ RSpec.describe PullRequest do
       expect(pr.validate_files_changed).to eq(true)
     end
 
-    it "returns true if PR only changes yarn.lock" do
+    it "returns false if PR only changes yarn.lock" do
       head_commit_api_response[:files][0][:filename] = "yarn.lock"
       stub_remote_commit(head_commit_api_response)
 
       pr = PullRequest.new(pull_request_api_response)
-      expect(pr.validate_files_changed).to eq(true)
+      expect(pr.validate_files_changed).to eq(false)
     end
 
-    it "returns true if PR changes package.json" do
+    it "returns false if PR changes package.json" do
       pkg_json = head_commit_api_response[:files].first.dup
       pkg_json[:filename] = "package.json"
       head_commit_api_response[:files] << pkg_json
       stub_remote_commit(head_commit_api_response)
 
       pr = PullRequest.new(pull_request_api_response)
-      expect(pr.validate_files_changed).to eq(true)
+      expect(pr.validate_files_changed).to eq(false)
     end
 
     it "returns false if PR changes anything else" do


### PR DESCRIPTION
Due to NPM supply chain compromise affecting a lot of JS packages.

Issue to make it configurable to follow.