### PR TITLE
✨ Add Dependabot configuration for automated dependency updates

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh pr:*)",
+      "Bash(gh run:*)",
+      "Bash(gh api:*)"
+    ]
+  }
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+
+updates:
+  - package-ecosystem: bundler
+    directory: /
+    schedule:
+      interval: monthly
+      time: "10:30"
+      timezone: "Europe/London"
+    cooldown:
+      default-days: 3
+    open-pull-requests-limit: 10
+    allow:
+      - dependency-type: direct
+    groups:
+      test:
+        patterns:
+          - "rspec"
+          - "rspec-*"
+          - "webmock"
+      lint:
+        patterns:
+          - "rubocop"
+          - "rubocop-*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+      time: "10:30"
+      timezone: "Europe/London"
+    cooldown:
+      default-days: 3


### PR DESCRIPTION
Configure Dependabot to monitor Bundler and GitHub Actions ecosystems following GOV.UK recommended settings from the developer docs.
