### PR TITLE
✨ Add Dependabot configuration for automated dependency updates

### DIFF
--- a/.github/.dependabot.yml
+++ b/.github/.dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+
+updates:
+  - package-ecosystem: bundler
+    directory: /
+    schedule:
+      interval: monthly
+      time: "10:30"
+      timezone: "Europe/London"
+    cooldown:
+      default-days: 3
+    open-pull-requests-limit: 10
+    allow:
+      - dependency-type: direct
+    groups:
+      test:
+        patterns:
+          - "rspec"
+          - "rspec-*"
+          - "webmock"
+      lint:
+        patterns:
+          - "rubocop"
+          - "rubocop-*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+      time: "10:30"
+      timezone: "Europe/London"
+    cooldown:
+      default-days: 3


### PR DESCRIPTION
## 👀 Purpose

- Enable Dependabot for the govuk-dependabot-merger repository to keep dependencies up to date automatically.

## ♻️ What's changed

- Added `.github/dependabot.yml` configured per the [GOV.UK developer docs recommendations](https://docs.publishing.service.gov.uk/manual/manage

## 📝 Notes

-