### PR TITLE
Use Renovate to manage .ruby-version file

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+  "enabledManagers": ["ruby-version"],
+  "minimumReleaseAge": "10 days"
+}


### PR DESCRIPTION
## What

Starts managing the Ruby version (in `.ruby-version`) with Renvoate. We should be able to use Renovate's built-in [.ruby-version manager](https://docs.renovatebot.com/modules/manager/ruby-version/) and not have to do anything else.

## How to review
Validate the config
Check my understanding