### PR TITLE
Upgrade ruby/setup-ruby to support ruby 4.0.2

### DIFF
--- a/.github/workflows/merge-dependabot-prs.yml
+++ b/.github/workflows/merge-dependabot-prs.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Setup ruby
-        uses: ruby/setup-ruby@1a615958ad9d422dd932dc1d5823942ee002799f #v1.227.0
+        uses: ruby/setup-ruby@c984c1a20bb35a1cbda04477c816cea024418be9 #v1.294.0
         with:
           bundler-cache: true
 


### PR DESCRIPTION
I noticed that the dependabot merger jobs are failing since this ruby v4 upgrade PR two days
ago (https://github.com/alphagov/govuk-dependabot-merger/pull/139).

Failing job: https://github.com/alphagov/govuk-dependabot-merger/actions/runs/25044621452/job/73356350768

I believe this is because the underlying github action ruby/setup-ruby is pinned to version 1.227 in the `merge-dependabot-prs.yml`. The package ruby/setup-ruby doesn't support ruby 4.0.2 until version 1.294.0.