### PR TITLE
Use latest version of `setup-ruby`

### DIFF
--- a/.github/workflows/merge-dependabot-prs.yml
+++ b/.github/workflows/merge-dependabot-prs.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Setup ruby
-        uses: ruby/setup-ruby@c984c1a20bb35a1cbda04477c816cea024418be9 #v1.294.0
+        uses: ruby/setup-ruby@c4e5b1316158f92e3d49443a9d58b31d25ac0f8f #v1.306.0
         with:
           bundler-cache: true
 


### PR DESCRIPTION
Since bumping the version of Ruby to `4.0.3`, the Merge Dependabot PRs action has failed. This brings the version of `Setup ruby` into line with the version used in the `CI` action, which should give us early warning of an incompatibilities in future.