### PR TITLE
[PP-7559] Remove govuk-graphql

### DIFF
--- a/config/repos_opted_in.yml
+++ b/config/repos_opted_in.yml
@@ -38,7 +38,6 @@
 - govuk-dependency-checker
 - govuk-developer-docs
 - govuk-docker
-- govuk-graphql
 - govuk-rota-announcer
 - govuk-rota-generator
 - govuk-saas-config


### PR DESCRIPTION
This repo has been archived, so we no longer need to merge dependency PRs.