### PR TITLE
Restore external dependency merging

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,22 +13,24 @@ For example:
 ```yaml
 api_version: 2
 defaults:
+  update_external_dependencies: false # default: false
   auto_merge: true # default: true
   allowed_semver_bumps: # allowed values: `[patch, minor, major]`
     - patch
     - minor
   # The above sets the default policy for all dependencies in your project.
-  # Only internal (govuk-owned) dependencies are eligible for auto-merging.
-  # External dependencies are never auto-merged.
-  # Each of the above properties can be overridden on a per-dependency basis below.
+  # But each of the above properties can be overridden on a per-dependency basis below.
 overrides:
   # Example of overriding `allowed_semver_bumps`:
-  - dependency: govuk_publishing_components
+  - dependency: rails
     allowed_semver_bumps:
-      - patch # minor/major bumps should be upgraded manually
+      - patch # minor/major bumps should be upgraded manually. See https://docs.publishing.service.gov.uk/manual/keeping-software-current.html#rails
   # Example of opting a specific dependency out of automatic patching:
   - dependency: gds-api-adapters
     auto_merge: false
+  # Example of opting a specific dependency into automatic patching:
+  - dependency: rspec
+    update_external_dependencies: true
 ```
 
 After you've merged your config file into your main branch, you just need to add your repository to the [config/repos_opted_in.yml](config/repos_opted_in.yml) list in govuk-dependabot-merger.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 This repository runs a daily GitHub action that automatically approves and merges certain Dependabot PRs for opted-in GOV.UK repos, according to [strict criteria set out in RFC-167](https://github.com/alphagov/govuk-rfcs/blob/main/rfc-167-auto-patch-dependencies.md#conditions-required-for-automatic-patching).
 
-Note that govuk-dependabot-merger will avoid merging a PR if it has a failing GitHub Action CI workflow called `CI`, [as per convention](https://docs.publishing.service.gov.uk/manual/test-and-build-a-project-with-github-actions.html#branch-protection-rules). It will also avoid running altogether on weekends and bank holidays.
+Note that govuk-dependabot-merger will avoid merging a PR if 
+* it has a failing GitHub Action CI workflow called `CI`, [as per convention](https://docs.publishing.service.gov.uk/manual/test-and-build-a-project-with-github-actions.html#branch-protection-rules), or
+* the smallest configured [Dependabot cooldown](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-) period is less than 3 days; if unconfigured, the cooldown period is treated as 0 days.  
+
+It will also avoid running altogether on weekends and bank holidays.
 
 ## Usage
 

--- a/lib/auto_merger.rb
+++ b/lib/auto_merger.rb
@@ -30,21 +30,15 @@ module AutoMerger
         puts "#{repo.name}: the remote .govuk_dependabot_merger.yml YAML syntax is corrupt."
       elsif !policy_manager.remote_config_api_version_supported?
         puts "#{repo.name}: the remote .govuk_dependabot_merger.yml file is using an unsupported API version."
+      elsif repo.dependabot_pull_requests.count.zero?
+        puts "#{repo.name}: no Dependabot PRs found."
       else
-        policy_manager.deprecated_config_warnings.each do |warning|
-          puts "#{repo.name}: WARNING - #{warning}"
-        end
+        puts "#{repo.dependabot_pull_requests.count} Dependabot PRs found for repo '#{repo.name}':"
 
-        if repo.dependabot_pull_requests.count.zero?
-          puts "#{repo.name}: no Dependabot PRs found."
-        else
-          puts "#{repo.dependabot_pull_requests.count} Dependabot PRs found for repo '#{repo.name}':"
+        repo.dependabot_pull_requests.each do |pr|
+          puts "  - Inspecting #{repo.name}##{pr.number}..."
 
-          repo.dependabot_pull_requests.each do |pr|
-            puts "  - Inspecting #{repo.name}##{pr.number}..."
-
-            merge_dependabot_pr(pr, policy_manager, dry_run:)
-          end
+          merge_dependabot_pr(pr, policy_manager, dry_run:)
         end
       end
     end

--- a/lib/auto_merger.rb
+++ b/lib/auto_merger.rb
@@ -22,7 +22,7 @@ module AutoMerger
 
   def self.merge_dependabot_prs(dry_run: false)
     Repo.all.each do |repo|
-      policy_manager = PolicyManager.new(repo.govuk_dependabot_merger_config)
+      policy_manager = PolicyManager.new(repo.govuk_dependabot_merger_config, repo.dependabot_cooldown_days)
 
       if !policy_manager.remote_config_exists?
         puts "#{repo.name}: the remote .govuk_dependabot_merger.yml file is missing."

--- a/lib/policy_manager.rb
+++ b/lib/policy_manager.rb
@@ -2,8 +2,9 @@ require_relative "./change_set"
 require_relative "./version"
 
 class PolicyManager
-  def initialize(remote_config = {})
+  def initialize(remote_config = {}, dependabot_cooldown_days = 0)
     @remote_config = remote_config
+    @dependabot_cooldown_days = dependabot_cooldown_days
   end
 
   def defaults
@@ -20,15 +21,37 @@ class PolicyManager
 
     update_external_dependencies = dependency_overrides["update_external_dependencies"].nil? ? defaults[:update_external_dependencies] : dependency_overrides["update_external_dependencies"]
     allowed_semver_bumps = dependency_overrides["allowed_semver_bumps"].nil? ? defaults[:allowed_semver_bumps] : dependency_overrides["allowed_semver_bumps"]
-    auto_merge = dependency_overrides["auto_merge"].nil? ? defaults[:auto_merge] : dependency_overrides["auto_merge"]
+    auto_merge_setting = dependency_overrides.fetch("auto_merge", defaults[:auto_merge])
 
     dependency = Dependency.new(dependency_name)
-    auto_merge = update_external_dependencies if auto_merge && !dependency.internal?
 
+    auto_merge = if dependency.internal?
+                   auto_merge_internal?(auto_merge_setting)
+                 else
+                   auto_merge_external?(dependency_name, auto_merge_setting, update_external_dependencies)
+                 end
     {
       auto_merge:,
       allowed_semver_bumps: auto_merge ? allowed_semver_bumps.map(&:to_sym) : [],
     }
+  end
+
+  def auto_merge_internal?(setting)
+    # the setting is respected at all times for internal dependencies
+    setting
+  end
+
+  def auto_merge_external?(dependency_name, auto_merge_setting, update_external_dependencies)
+    unless update_external_dependencies
+      false
+    else
+      if auto_merge_setting && !dependabot_cooldown_days_acceptable?
+        puts "blocking auto merging of #{dependency_name} because the configured dependabot cooldown is too low (#{@dependabot_cooldown_days})"
+        false
+      else
+        auto_merge_setting
+      end
+    end
   end
 
   def remote_config_exists?
@@ -45,6 +68,10 @@ class PolicyManager
 
   def is_auto_mergeable?(pull_request)
     reasons_not_to_merge(pull_request).count.zero?
+  end
+
+  def dependabot_cooldown_days_acceptable?
+    @dependabot_cooldown_days >= 3
   end
 
   def reasons_not_to_merge(pull_request)

--- a/lib/policy_manager.rb
+++ b/lib/policy_manager.rb
@@ -29,24 +29,6 @@ class PolicyManager
     }
   end
 
-  def deprecated_config_warnings
-    warnings = []
-    defaults = @remote_config["defaults"] || {}
-    overrides = @remote_config["overrides"] || []
-
-    if defaults.key?("update_external_dependencies")
-      warnings << "the `update_external_dependencies` setting in `defaults` is deprecated and will be ignored. External dependencies are no longer auto-merged."
-    end
-
-    overrides.each do |override|
-      if override.key?("update_external_dependencies")
-        warnings << "the `update_external_dependencies` setting for `#{override['dependency']}` is deprecated and will be ignored. External dependencies are no longer auto-merged."
-      end
-    end
-
-    warnings
-  end
-
   def remote_config_exists?
     @remote_config["error"] != "404"
   end

--- a/lib/policy_manager.rb
+++ b/lib/policy_manager.rb
@@ -11,7 +11,7 @@ class PolicyManager
     defaults = @remote_config["defaults"] || {}
     {
       update_external_dependencies: defaults["update_external_dependencies"].nil? ? false : defaults["update_external_dependencies"],
-      auto_merge: defaults["auto_merge"].nil? ? true : defaults["auto_merge"],
+      auto_merge: defaults["auto_merge"].nil? || defaults["auto_merge"],
       allowed_semver_bumps: defaults["allowed_semver_bumps"].nil? ? %i[patch minor] : defaults["allowed_semver_bumps"],
     }
   end
@@ -42,15 +42,15 @@ class PolicyManager
   end
 
   def auto_merge_external?(dependency_name, auto_merge_setting, update_external_dependencies)
-    unless update_external_dependencies
-      false
-    else
+    if update_external_dependencies
       if auto_merge_setting && !dependabot_cooldown_days_acceptable?
         puts "blocking auto merging of #{dependency_name} because the configured dependabot cooldown is too low (#{@dependabot_cooldown_days})"
         false
       else
         auto_merge_setting
       end
+    else
+      false
     end
   end
 

--- a/lib/policy_manager.rb
+++ b/lib/policy_manager.rb
@@ -9,7 +9,8 @@ class PolicyManager
   def defaults
     defaults = @remote_config["defaults"] || {}
     {
-      auto_merge: defaults["auto_merge"].nil? || defaults["auto_merge"],
+      update_external_dependencies: defaults["update_external_dependencies"].nil? ? false : defaults["update_external_dependencies"],
+      auto_merge: defaults["auto_merge"].nil? ? true : defaults["auto_merge"],
       allowed_semver_bumps: defaults["allowed_semver_bumps"].nil? ? %i[patch minor] : defaults["allowed_semver_bumps"],
     }
   end
@@ -17,11 +18,12 @@ class PolicyManager
   def dependency_policy(dependency_name)
     dependency_overrides = @remote_config["overrides"]&.find { |dependency| dependency["dependency"] == dependency_name } || {}
 
+    update_external_dependencies = dependency_overrides["update_external_dependencies"].nil? ? defaults[:update_external_dependencies] : dependency_overrides["update_external_dependencies"]
     allowed_semver_bumps = dependency_overrides["allowed_semver_bumps"].nil? ? defaults[:allowed_semver_bumps] : dependency_overrides["allowed_semver_bumps"]
     auto_merge = dependency_overrides["auto_merge"].nil? ? defaults[:auto_merge] : dependency_overrides["auto_merge"]
 
     dependency = Dependency.new(dependency_name)
-    auto_merge = false if auto_merge && !dependency.internal?
+    auto_merge = update_external_dependencies if auto_merge && !dependency.internal?
 
     {
       auto_merge:,

--- a/lib/repo.rb
+++ b/lib/repo.rb
@@ -34,4 +34,28 @@ Repo = Struct.new(:name) do
   def dependabot_pull_request(pr_number)
     PullRequest.new(GitHubClient.instance.pull_request("alphagov/#{name}", pr_number))
   end
+
+  def dependabot_cooldown_days
+    GitHubClient.instance
+      .contents(
+        "alphagov/#{name}",
+        {
+          accept: "application/vnd.github.raw",
+          path: ".github/dependabot.yml",
+        },
+      )
+      .then { |content|
+        cfg = YAML.safe_load(content)
+
+        return 0 if !cfg.has_key?("updates") || cfg["updates"].length == 0
+
+        return cfg["updates"].map { |update|
+          update.dig("cooldown", "default-days") || 0
+        }.min
+      }
+  rescue Octokit::NotFound
+    { "error" => "404" }
+  rescue Psych::SyntaxError
+    { "error" => "syntax" }
+  end
 end

--- a/lib/repo.rb
+++ b/lib/repo.rb
@@ -44,15 +44,15 @@ Repo = Struct.new(:name) do
           path: ".github/dependabot.yml",
         },
       )
-      .then { |content|
+      .then do |content|
         cfg = YAML.safe_load(content)
 
-        return 0 if !cfg.has_key?("updates") || cfg["updates"].length == 0
+        return 0 if !cfg.key?("updates") || cfg["updates"].empty?
 
         return cfg["updates"].map { |update|
           update.dig("cooldown", "default-days") || 0
         }.min
-      }
+      end
   rescue Octokit::NotFound
     { "error" => "404" }
   rescue Psych::SyntaxError

--- a/spec/lib/auto_merger_spec.rb
+++ b/spec/lib/auto_merger_spec.rb
@@ -12,7 +12,6 @@ RSpec.describe AutoMerger do
     allow(mock_policy_manager).to receive(:valid_remote_config_syntax?).and_return(true)
     allow(mock_policy_manager).to receive(:remote_config_api_version_supported?).and_return(true)
     allow(mock_policy_manager).to receive(:is_auto_mergeable?).and_return(true)
-    allow(mock_policy_manager).to receive(:deprecated_config_warnings).and_return([])
     allow(PolicyManager).to receive(:new).and_return(mock_policy_manager)
     mock_policy_manager
   end

--- a/spec/lib/auto_merger_spec.rb
+++ b/spec/lib/auto_merger_spec.rb
@@ -50,8 +50,8 @@ RSpec.describe AutoMerger do
       mock_pr_1 = instance_double("PullRequest", number: 1)
       mock_pr_2 = instance_double("PullRequest", number: 2)
       mock_pr_3 = instance_double("PullRequest", number: 3)
-      mock_repo_1 = instance_double("Repo", name: "Repo 1", govuk_dependabot_merger_config: {}, dependabot_pull_requests: [mock_pr_1])
-      mock_repo_2 = instance_double("Repo", name: "Repo 2", govuk_dependabot_merger_config: {}, dependabot_pull_requests: [mock_pr_2, mock_pr_3])
+      mock_repo_1 = instance_double("Repo", name: "Repo 1", govuk_dependabot_merger_config: {}, dependabot_pull_requests: [mock_pr_1], dependabot_cooldown_days: 5)
+      mock_repo_2 = instance_double("Repo", name: "Repo 2", govuk_dependabot_merger_config: {}, dependabot_pull_requests: [mock_pr_2, mock_pr_3], dependabot_cooldown_days: 5)
       allow(Repo).to receive(:all).and_return([
         mock_repo_1,
         mock_repo_2,
@@ -66,7 +66,7 @@ RSpec.describe AutoMerger do
 
     it "forwards the `dry_run` keyword arg if passed" do
       mock_pr = instance_double("PullRequest", number: 1)
-      mock_repo = instance_double("Repo", name: "Repo", govuk_dependabot_merger_config: {}, dependabot_pull_requests: [mock_pr])
+      mock_repo = instance_double("Repo", name: "Repo", govuk_dependabot_merger_config: {}, dependabot_pull_requests: [mock_pr], dependabot_cooldown_days: 5)
       allow(Repo).to receive(:all).and_return([mock_repo])
 
       expect(AutoMerger).to receive(:merge_dependabot_pr).with(mock_pr, policy_manager, dry_run: true)
@@ -75,7 +75,7 @@ RSpec.describe AutoMerger do
     end
 
     it "should make a call to PolicyManager.remote_config_exists?, which should block merge if false" do
-      mock_repo = instance_double("Repo", name: "Repo 1", govuk_dependabot_merger_config: {}, dependabot_pull_requests: [mock_pr])
+      mock_repo = instance_double("Repo", name: "Repo 1", govuk_dependabot_merger_config: {}, dependabot_pull_requests: [mock_pr], dependabot_cooldown_days: 5)
       allow(Repo).to receive(:all).and_return([mock_repo])
 
       allow(policy_manager).to receive(:remote_config_exists?).and_return(false)
@@ -86,7 +86,7 @@ RSpec.describe AutoMerger do
     end
 
     it "should make a call to PolicyManager.valid_remote_config_syntax?, which should block merge if false" do
-      mock_repo = instance_double("Repo", name: "Repo 1", govuk_dependabot_merger_config: {}, dependabot_pull_requests: [mock_pr])
+      mock_repo = instance_double("Repo", name: "Repo 1", govuk_dependabot_merger_config: {}, dependabot_pull_requests: [mock_pr], dependabot_cooldown_days: 5)
       allow(Repo).to receive(:all).and_return([mock_repo])
 
       allow(policy_manager).to receive(:valid_remote_config_syntax?).and_return(false)
@@ -97,7 +97,7 @@ RSpec.describe AutoMerger do
     end
 
     it "should make a call to PolicyManager.remote_config_api_version_supported?, which should block merge if false" do
-      mock_repo = instance_double("Repo", name: "Repo 1", govuk_dependabot_merger_config: {}, dependabot_pull_requests: [mock_pr])
+      mock_repo = instance_double("Repo", name: "Repo 1", govuk_dependabot_merger_config: {}, dependabot_pull_requests: [mock_pr], dependabot_cooldown_days: 5)
       allow(Repo).to receive(:all).and_return([mock_repo])
 
       allow(policy_manager).to receive(:remote_config_api_version_supported?).and_return(false)
@@ -109,7 +109,7 @@ RSpec.describe AutoMerger do
 
     it "should announce when no Dependabot PRs were found" do
       policy_manager # set up the mock policy manager object
-      mock_repo = instance_double("Repo", name: "Repo 1", govuk_dependabot_merger_config: {}, dependabot_pull_requests: [])
+      mock_repo = instance_double("Repo", name: "Repo 1", govuk_dependabot_merger_config: {}, dependabot_pull_requests: [], dependabot_cooldown_days: 5)
       allow(Repo).to receive(:all).and_return([mock_repo])
 
       expect(AutoMerger).to_not receive(:merge_dependabot_pr)

--- a/spec/lib/policy_manager_spec.rb
+++ b/spec/lib/policy_manager_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe PolicyManager do
       let(:expected_policy) { { auto_merge: true, allowed_semver_bumps: } }
       it { expect(policy_manager.dependency_policy(external_dependency)).to eq(expected_policy) }
     end
-    let(:policy_manager) { PolicyManager.new(remote_config) }
+    let(:policy_manager) { PolicyManager.new(remote_config, 5) }
     let(:remote_config) do
       {
         "defaults" => {
@@ -88,6 +88,30 @@ RSpec.describe PolicyManager do
 
       it_behaves_like "allows auto-merging internal dependencies"
       it_behaves_like "allows auto-merging external dependencies"
+    end
+
+    context "dependabot cooldown days is less than 3" do
+      let(:policy_manager) { PolicyManager.new(remote_config, 1) }
+
+      context "auto merge enabled, external dependencies enabled" do
+        let(:auto_merge) { true }
+        let(:update_external_dependencies) { true }
+
+        it_behaves_like "allows auto-merging internal dependencies"
+        it_behaves_like "doesn't allow auto-merging external dependencies"
+      end
+    end
+
+    context "dependabot cooldown days is >= 3 days" do
+      let(:policy_manager) { PolicyManager.new(remote_config, 5) }
+
+      context "auto merge enabled, external dependencies enabled" do
+        let(:auto_merge) { true }
+        let(:update_external_dependencies) { true }
+
+        it_behaves_like "allows auto-merging internal dependencies"
+        it_behaves_like "allows auto-merging external dependencies"
+      end
     end
 
     context "general tests for overrides" do

--- a/spec/lib/policy_manager_spec.rb
+++ b/spec/lib/policy_manager_spec.rb
@@ -333,7 +333,7 @@ RSpec.describe PolicyManager do
           updated-dependencies:
           - dependency-name: #{external_dependency}
             dependency-type: direct:production
-            update-type: version-update:semver-minor
+            update-type: version-update:semver-patch
         COMMIT_MESSAGE
       )
 

--- a/spec/lib/policy_manager_spec.rb
+++ b/spec/lib/policy_manager_spec.rb
@@ -5,9 +5,15 @@ RSpec.describe PolicyManager do
   describe "#defaults" do
     it "returns set of default behaviours" do
       expect(PolicyManager.new.defaults).to eq({
+        update_external_dependencies: false,
         auto_merge: true,
         allowed_semver_bumps: %i[patch minor],
       })
+    end
+
+    it "can override the default `update_external_dependencies` property via remote config" do
+      remote_config = { "defaults" => { "update_external_dependencies" => true } }
+      expect(PolicyManager.new(remote_config).defaults[:update_external_dependencies]).to eq(true)
     end
 
     it "can override the default `auto_merge` property via remote config" do
@@ -34,10 +40,15 @@ RSpec.describe PolicyManager do
       let(:expected_policy) { { auto_merge: true, allowed_semver_bumps: } }
       it { expect(policy_manager.dependency_policy(internal_dependency)).to eq(expected_policy) }
     end
+    RSpec.shared_examples "allows auto-merging external dependencies" do
+      let(:expected_policy) { { auto_merge: true, allowed_semver_bumps: } }
+      it { expect(policy_manager.dependency_policy(external_dependency)).to eq(expected_policy) }
+    end
     let(:policy_manager) { PolicyManager.new(remote_config) }
     let(:remote_config) do
       {
         "defaults" => {
+          "update_external_dependencies" => update_external_dependencies,
           "auto_merge" => auto_merge,
           "allowed_semver_bumps" => allowed_semver_bumps,
         },
@@ -47,22 +58,44 @@ RSpec.describe PolicyManager do
     let(:internal_dependency) { stub_internal_dependency("govuk_publishing_components") }
     let(:external_dependency) { stub_external_dependency("foo") }
 
-    context "auto merge disabled" do
+    context "auto merge disabled, external dependencies disabled" do
       let(:auto_merge) { false }
+      let(:update_external_dependencies) { false }
 
       it_behaves_like "doesn't allow auto-merging internal dependencies"
       it_behaves_like "doesn't allow auto-merging external dependencies"
     end
 
-    context "auto merge enabled" do
+    context "auto merge disabled, external dependencies enabled" do
+      let(:auto_merge) { false }
+      let(:update_external_dependencies) { true }
+
+      it_behaves_like "doesn't allow auto-merging internal dependencies"
+      it_behaves_like "doesn't allow auto-merging external dependencies"
+    end
+
+    context "auto merge enabled, external dependencies disabled" do
       let(:auto_merge) { true }
+      let(:update_external_dependencies) { false }
 
       it_behaves_like "allows auto-merging internal dependencies"
       it_behaves_like "doesn't allow auto-merging external dependencies"
     end
 
-    context "general tests for overrides" do
+    context "auto merge enabled, external dependencies enabled" do
       let(:auto_merge) { true }
+      let(:update_external_dependencies) { true }
+
+      it_behaves_like "allows auto-merging internal dependencies"
+      it_behaves_like "allows auto-merging external dependencies"
+    end
+
+    context "general tests for overrides" do
+      # these `let`s are included so `remote_config` doesn't raise an exception, but each
+      # individual test should override the relevant bits of `remote_config["defaults"]`
+      # for explicitness.
+      let(:auto_merge) { true }
+      let(:update_external_dependencies) { true }
 
       it "refers to overridden 'allowed_semver_bumps' value for dependencies if provided" do
         remote_config["defaults"]["allowed_semver_bumps"] = %i[patch]
@@ -92,13 +125,25 @@ RSpec.describe PolicyManager do
         })
       end
 
-      it "never allows auto-merging external dependencies even with auto_merge override" do
+      it "doesn't allow auto-merging external dependencies if they override `update_external_dependencies` to false" do
         remote_config["defaults"]["auto_merge"] = true
-        remote_config["overrides"] = [{ "dependency" => external_dependency, "auto_merge" => true }]
+        remote_config["defaults"]["update_external_dependencies"] = true
+        remote_config["overrides"] = [{ "dependency" => external_dependency, "update_external_dependencies" => false }]
 
         expect(policy_manager.dependency_policy(external_dependency)).to eq({
           auto_merge: false,
           allowed_semver_bumps: [],
+        })
+      end
+
+      it "allows allow-listed external dependencies to be auto-merged" do
+        remote_config["defaults"]["auto_merge"] = false
+        remote_config["defaults"]["update_external_dependencies"] = true
+        remote_config["overrides"] = [{ "dependency" => external_dependency, "auto_merge" => true }]
+
+        expect(policy_manager.dependency_policy(external_dependency)).to eq({
+          auto_merge: true,
+          allowed_semver_bumps:,
         })
       end
 
@@ -112,19 +157,41 @@ RSpec.describe PolicyManager do
         })
       end
 
+      it "doesn't allow overridden external dependencies to be auto-merged (due to `update_external_dependencies`)" do
+        remote_config["defaults"]["auto_merge"] = false
+        remote_config["defaults"]["update_external_dependencies"] = false
+        remote_config["overrides"] = [{ "dependency" => external_dependency, "auto_merge" => true }]
+
+        expect(policy_manager.dependency_policy(external_dependency)).to eq({
+          auto_merge: false,
+          allowed_semver_bumps: [],
+        })
+      end
+
+      it "allows overridden external dependencies to be auto-merged if `update_external_dependencies` is overridden to `true`" do
+        remote_config["defaults"]["auto_merge"] = false
+        remote_config["defaults"]["update_external_dependencies"] = false
+        remote_config["overrides"] = [{ "dependency" => external_dependency, "auto_merge" => true, "update_external_dependencies" => true }]
+
+        expect(policy_manager.dependency_policy(external_dependency)).to eq({
+          auto_merge: true,
+          allowed_semver_bumps:,
+        })
+      end
+
       it "converts default allowed_semver_bumps to symbols" do
         remote_config["defaults"]["allowed_semver_bumps"] = %w[patch minor]
 
-        expect(policy_manager.dependency_policy(internal_dependency)).to eq({
+        expect(policy_manager.dependency_policy(external_dependency)).to eq({
           auto_merge: true,
           allowed_semver_bumps: %i[patch minor],
         })
       end
 
       it "converts overridden allowed_semver_bumps to symbols" do
-        remote_config["overrides"] = [{ "dependency" => internal_dependency, "allowed_semver_bumps" => %w[patch] }]
+        remote_config["overrides"] = [{ "dependency" => external_dependency, "allowed_semver_bumps" => %w[patch] }]
 
-        expect(policy_manager.dependency_policy(internal_dependency)).to eq({
+        expect(policy_manager.dependency_policy(external_dependency)).to eq({
           auto_merge: true,
           allowed_semver_bumps: %i[patch],
         })
@@ -169,38 +236,6 @@ RSpec.describe PolicyManager do
       policy_manager = PolicyManager.new
       allow(policy_manager).to receive(:dependency_policy).and_return(auto_merge: true, allowed_semver_bumps: %i[patch])
       expect(policy_manager.change_allowed?("foo", :patch)).to eq(true)
-    end
-  end
-
-  describe "#deprecated_config_warnings" do
-    it "returns no warnings when update_external_dependencies is not present" do
-      remote_config = { "defaults" => { "auto_merge" => true } }
-      expect(PolicyManager.new(remote_config).deprecated_config_warnings).to eq([])
-    end
-
-    it "returns a warning when update_external_dependencies is in defaults" do
-      remote_config = { "defaults" => { "update_external_dependencies" => true } }
-      warnings = PolicyManager.new(remote_config).deprecated_config_warnings
-      expect(warnings.length).to eq(1)
-      expect(warnings.first).to include("update_external_dependencies")
-      expect(warnings.first).to include("deprecated")
-    end
-
-    it "returns a warning when update_external_dependencies is in an override" do
-      remote_config = { "defaults" => {}, "overrides" => [{ "dependency" => "rspec", "update_external_dependencies" => true }] }
-      warnings = PolicyManager.new(remote_config).deprecated_config_warnings
-      expect(warnings.length).to eq(1)
-      expect(warnings.first).to include("rspec")
-      expect(warnings.first).to include("deprecated")
-    end
-
-    it "returns multiple warnings when present in both defaults and overrides" do
-      remote_config = {
-        "defaults" => { "update_external_dependencies" => false },
-        "overrides" => [{ "dependency" => "rspec", "update_external_dependencies" => true }],
-      }
-      warnings = PolicyManager.new(remote_config).deprecated_config_warnings
-      expect(warnings.length).to eq(2)
     end
   end
 
@@ -254,6 +289,7 @@ RSpec.describe PolicyManager do
         "api_version" => DependabotAutoMerge::VERSION,
         "defaults" => {
           "auto_merge" => true,
+          "update_external_dependencies" => true,
           "allowed_semver_bumps" => %i[patch minor],
         },
         "overrides" => [
@@ -261,6 +297,11 @@ RSpec.describe PolicyManager do
             # example of being stricter about semver for certain dependencies
             "dependency" => internal_dependency,
             "allowed_semver_bumps" => %i[patch],
+          },
+          {
+            # example of deny-listing a named external dependency
+            "dependency" => external_dependency,
+            "update_external_dependencies" => false,
           },
         ],
       }
@@ -284,7 +325,7 @@ RSpec.describe PolicyManager do
       ])
     end
 
-    it "should return reasons not to merge an external dependency" do
+    it "should return reasons not to merge the example external dependency" do
       mock_pr = instance_double("PullRequest")
       allow(mock_pr).to receive(:commit_message).and_return(
         <<~COMMIT_MESSAGE,
@@ -292,7 +333,7 @@ RSpec.describe PolicyManager do
           updated-dependencies:
           - dependency-name: #{external_dependency}
             dependency-type: direct:production
-            update-type: version-update:semver-patch
+            update-type: version-update:semver-minor
         COMMIT_MESSAGE
       )
 

--- a/spec/lib/repo_spec.rb
+++ b/spec/lib/repo_spec.rb
@@ -5,11 +5,97 @@ RSpec.describe Repo do
 
   let(:repo_name) { "foo" }
   let(:external_config_file_api_url) { "https://api.github.com/repos/alphagov/#{repo_name}/contents/.govuk_dependabot_merger.yml" }
+  let(:external_dependabot_config_file_api_url) { "https://api.github.com/repos/alphagov/#{repo_name}/contents/.github/dependabot.yml" }
   let(:arbitrary_config) do
     <<~EXTERNAL_CONFIG_YAML
       foo: bar
     EXTERNAL_CONFIG_YAML
   end
+  let(:dependabot_config_with_all_cooldown_days_config) do
+    <<~DEPENDABOT_CONFIG
+      ---
+      version: 2
+      
+      updates:
+        - package-ecosystem: bundler
+          directory: /
+          schedule:
+            interval: monthly
+            time: "10:30"
+            timezone: "Europe/London"
+          cooldown:
+            default-days: 6
+          open-pull-requests-limit: 10
+          allow:
+            - dependency-type: direct
+          groups:
+            test:
+              patterns:
+                - "rspec"
+                - "rspec-*"
+                - "webmock"
+            lint:
+              patterns:
+                - "rubocop"
+                - "rubocop-*"
+      
+        - package-ecosystem: github-actions
+          directory: /
+          schedule:
+            interval: monthly
+            time: "10:30"
+            timezone: "Europe/London"
+          cooldown:
+            default-days: 3      
+    DEPENDABOT_CONFIG
+  end
+
+  let(:dependabot_config_with_missing_cooldown_days_config) do
+    <<~DEPENDABOT_CONFIG
+      ---
+      version: 2
+      
+      updates:
+        - package-ecosystem: bundler
+          directory: /
+          schedule:
+            interval: monthly
+            time: "10:30"
+            timezone: "Europe/London"
+          cooldown:
+            default-days: 1
+          open-pull-requests-limit: 10
+          allow:
+            - dependency-type: direct
+          groups:
+            test:
+              patterns:
+                - "rspec"
+                - "rspec-*"
+                - "webmock"
+            lint:
+              patterns:
+                - "rubocop"
+                - "rubocop-*"
+      
+        - package-ecosystem: github-actions
+          directory: /
+          schedule:
+            interval: monthly
+            time: "10:30"
+            timezone: "Europe/London"      
+    DEPENDABOT_CONFIG
+  end
+
+  let(:dependabot_config_with_no_updates) do
+    <<~DEPENDABOT_CONFIG
+      ---
+      version: 2
+      
+      updates: []      
+    DEPENDABOT_CONFIG
+  end
+
 
   describe ".all" do
     it "should return an array of Repo objects" do
@@ -80,6 +166,36 @@ RSpec.describe Repo do
       repo = Repo.new(repo_name)
       expect(repo.dependabot_pull_requests).to all be_a_kind_of(PullRequest)
       expect(repo.dependabot_pull_requests.count).to eq(1)
+    end
+  end
+
+  describe "#dependabot_cooldown_days" do
+    it "returns the smallest configured dependency cooldown in days" do
+      stub_request(:get, external_dependabot_config_file_api_url)
+        .to_return(status: 200, body: dependabot_config_with_all_cooldown_days_config.to_json, headers: { "Content-Type": "application/json" })
+
+      repo = Repo.new(repo_name)
+      expect(repo.dependabot_cooldown_days).to eq(3)
+    end
+
+    context "when an update configuration is missing a cooldown days setting" do
+      it "returns zero as the dependency cooldown in days" do
+        stub_request(:get, external_dependabot_config_file_api_url)
+          .to_return(status: 200, body: dependabot_config_with_missing_cooldown_days_config.to_json, headers: { "Content-Type": "application/json" })
+
+        repo = Repo.new(repo_name)
+        expect(repo.dependabot_cooldown_days).to eq(0)
+      end
+    end
+
+    context "when the dependabot configuration has no updates configured" do
+      it "returns zero as the dependency cooldown in days" do
+        stub_request(:get, external_dependabot_config_file_api_url)
+          .to_return(status: 200, body: dependabot_config_with_no_updates.to_json, headers: { "Content-Type": "application/json" })
+
+        repo = Repo.new(repo_name)
+        expect(repo.dependabot_cooldown_days).to eq(0)
+      end
     end
   end
 end

--- a/spec/lib/repo_spec.rb
+++ b/spec/lib/repo_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Repo do
     <<~DEPENDABOT_CONFIG
       ---
       version: 2
-      
+
       updates:
         - package-ecosystem: bundler
           directory: /
@@ -38,7 +38,7 @@ RSpec.describe Repo do
               patterns:
                 - "rubocop"
                 - "rubocop-*"
-      
+
         - package-ecosystem: github-actions
           directory: /
           schedule:
@@ -46,7 +46,7 @@ RSpec.describe Repo do
             time: "10:30"
             timezone: "Europe/London"
           cooldown:
-            default-days: 3      
+            default-days: 3#{'      '}
     DEPENDABOT_CONFIG
   end
 
@@ -54,7 +54,7 @@ RSpec.describe Repo do
     <<~DEPENDABOT_CONFIG
       ---
       version: 2
-      
+
       updates:
         - package-ecosystem: bundler
           directory: /
@@ -77,13 +77,13 @@ RSpec.describe Repo do
               patterns:
                 - "rubocop"
                 - "rubocop-*"
-      
+
         - package-ecosystem: github-actions
           directory: /
           schedule:
             interval: monthly
             time: "10:30"
-            timezone: "Europe/London"      
+            timezone: "Europe/London"#{'      '}
     DEPENDABOT_CONFIG
   end
 
@@ -91,11 +91,10 @@ RSpec.describe Repo do
     <<~DEPENDABOT_CONFIG
       ---
       version: 2
-      
-      updates: []      
+
+      updates: []#{'      '}
     DEPENDABOT_CONFIG
   end
-
 
   describe ".all" do
     it "should return an array of Repo objects" do


### PR DESCRIPTION
## What

Resolves https://github.com/alphagov/govuk-infrastructure/issues/4087 by determining the minimum Dependabot dependency cooldown period, and preventing automatic merging of external dependencies if that number is less than 3.

## How to test
1. Code review. Look particularly at test cases: are there any useful ones I've not thought of?