### PR TITLE
Add Fact Check Manager to opted-in repos

### DIFF
--- a/config/repos_opted_in.yml
+++ b/config/repos_opted_in.yml
@@ -16,6 +16,7 @@
 - email-alert-api
 - email-alert-frontend
 - email-alert-service
+- fact-check-manager
 - feedback
 - finder-frontend
 - frontend


### PR DESCRIPTION
## Summary
- Adds Fact Check Manager to the list of repos opted into the auto-merger
- The corresponding config file has been added to the repo https://github.com/alphagov/fact-check-manager/blob/main/.govuk_dependabot_merger.yml