### PR TITLE
Allow Golang and GitHub actions dependency changes

### DIFF
--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -40,8 +40,23 @@ class PullRequest
   def validate_files_changed
     commit = GitHubClient.instance.commit("alphagov/#{@api_response.base.repo.name}", @api_response.head.sha)
     files_changed = commit.files.map(&:filename)
-    allowed_files = ["yarn.lock", "package.json", "Gemfile.lock", "Gemfile", "#{@api_response.base.repo.name}.gemspec", "go.mod", "go.sum"]
-    (files_changed - allowed_files).empty?
+    allowed_file_patterns = [
+      "yarn.lock",
+      "package.json",
+      "Gemfile.lock",
+      "Gemfile",
+      "#{@api_response.base.repo.name}.gemspec",
+      "go.mod",
+      "go.sum",
+      ".github/workflows/*.yml",
+      ".github/workflows/*.yaml",
+    ]
+    compiled_pattern = "{#{allowed_file_patterns.join(',')}}"
+
+    # return false if any changed file hasn't matched any of the patterns
+    files_changed.none? do |path|
+      !File.fnmatch(compiled_pattern, path, File::FNM_EXTGLOB)
+    end
   end
 
   def validate_ci_workflow_exists

--- a/lib/pull_request.rb
+++ b/lib/pull_request.rb
@@ -40,7 +40,7 @@ class PullRequest
   def validate_files_changed
     commit = GitHubClient.instance.commit("alphagov/#{@api_response.base.repo.name}", @api_response.head.sha)
     files_changed = commit.files.map(&:filename)
-    allowed_files = ["yarn.lock", "package.json", "Gemfile.lock", "Gemfile", "#{@api_response.base.repo.name}.gemspec"]
+    allowed_files = ["yarn.lock", "package.json", "Gemfile.lock", "Gemfile", "#{@api_response.base.repo.name}.gemspec", "go.mod", "go.sum"]
     (files_changed - allowed_files).empty?
   end
 

--- a/spec/lib/pull_request_spec.rb
+++ b/spec/lib/pull_request_spec.rb
@@ -229,8 +229,36 @@ RSpec.describe PullRequest do
       expect(pr.validate_files_changed).to eq(true)
     end
 
-    it "returns false if PR changes anything else" do
-      head_commit_api_response[:files][0][:filename] = "something_else.rb"
+    it "returns true if PR changes go.mod" do
+      pkg_json = head_commit_api_response[:files].first.dup
+      pkg_json[:filename] = "go.mod"
+      head_commit_api_response[:files] << pkg_json
+      stub_remote_commit(head_commit_api_response)
+
+      pr = PullRequest.new(pull_request_api_response)
+      expect(pr.validate_files_changed).to eq(true)
+    end
+
+    it "returns true if PR changes go.sum" do
+      pkg_json = head_commit_api_response[:files].first.dup
+      pkg_json[:filename] = "go.sum"
+      head_commit_api_response[:files] << pkg_json
+      stub_remote_commit(head_commit_api_response)
+
+      pr = PullRequest.new(pull_request_api_response)
+      expect(pr.validate_files_changed).to eq(true)
+    end
+
+    it "returns false if PR changes anything else other than the allowed files" do
+      pkg_json = head_commit_api_response[:files].first.dup
+      pkg_json[:filename] = "package.json"
+
+      other = head_commit_api_response[:files].first.dup
+      other[:filename] = "something_else.rb"
+
+      head_commit_api_response[:files] << pkg_json
+      head_commit_api_response[:files] << other
+
       stub_remote_commit(head_commit_api_response)
 
       pr = PullRequest.new(pull_request_api_response)

--- a/spec/lib/pull_request_spec.rb
+++ b/spec/lib/pull_request_spec.rb
@@ -249,6 +249,26 @@ RSpec.describe PullRequest do
       expect(pr.validate_files_changed).to eq(true)
     end
 
+    it "returns true if PR changes a GitHub Actions workflow YML file" do
+      gha_workflow = head_commit_api_response[:files].first.dup
+      gha_workflow[:filename] = ".github/workflows/ci.yml"
+      head_commit_api_response[:files] << gha_workflow
+      stub_remote_commit(head_commit_api_response)
+
+      pr = PullRequest.new(pull_request_api_response)
+      expect(pr.validate_files_changed).to eq(true)
+    end
+
+    it "returns true if PR changes a GitHub Actions workflow YAML file" do
+      gha_workflow = head_commit_api_response[:files].first.dup
+      gha_workflow[:filename] = ".github/workflows/ci.yaml"
+      head_commit_api_response[:files] << gha_workflow
+      stub_remote_commit(head_commit_api_response)
+
+      pr = PullRequest.new(pull_request_api_response)
+      expect(pr.validate_files_changed).to eq(true)
+    end
+
     it "returns false if PR changes anything else other than the allowed files" do
       pkg_json = head_commit_api_response[:files].first.dup
       pkg_json[:filename] = "package.json"


### PR DESCRIPTION
## What

Allows Golang and GitHub Actions dependencies to be bumped

## How to review

1. Code review
2. Check the tests