### PR TITLE
Enable automatic pagination in the GitHub Ocotkit library

### DIFF
--- a/lib/github_client.rb
+++ b/lib/github_client.rb
@@ -5,7 +5,9 @@ class GitHubAuthException < StandardError; end
 
 module GitHubClient
   def self.instance
-    Octokit::Client.new(access_token: token)
+    client = Octokit::Client.new(access_token: token)
+    client.auto_paginate = true
+    client
   end
 
   def self.get(url)

--- a/spec/lib/github_client_spec.rb
+++ b/spec/lib/github_client_spec.rb
@@ -12,6 +12,12 @@ RSpec.describe GitHubClient do
       set_up_mock_token
       expect(GitHubClient.instance).to be_a_kind_of(Octokit::Client)
     end
+
+    it "should return an instance with auto_paginate enabled" do
+      set_up_mock_token
+      gh = GitHubClient.instance
+      expect(gh.auto_paginate).to be true
+    end
   end
 
   describe ".get" do

--- a/spec/lib/pull_request_spec.rb
+++ b/spec/lib/pull_request_spec.rb
@@ -174,7 +174,7 @@ RSpec.describe PullRequest do
         },
       }
     end
-    let(:commit_api_url) { "https://api.github.com/repos/alphagov/#{repo_name}/pulls/1/commits" }
+    let(:commit_api_url) { "https://api.github.com/repos/alphagov/#{repo_name}/pulls/1/commits?per_page=100" }
 
     it "return true if PR contains a single commit" do
       stub_request(:get, commit_api_url)

--- a/spec/lib/repo_spec.rb
+++ b/spec/lib/repo_spec.rb
@@ -143,10 +143,11 @@ RSpec.describe Repo do
   end
 
   describe "#dependabot_pull_requests" do
+    let(:pull_requests_url) { "https://api.github.com/repos/alphagov/#{repo_name}/pulls?per_page=100&sort=created&state=open" }
     it "should return an array of PullRequest objects" do
       stub_request(:get, external_config_file_api_url)
         .to_return(status: 200, body: arbitrary_config.to_json, headers: { "Content-Type": "application/json" })
-      stub_request(:get, "https://api.github.com/repos/alphagov/#{repo_name}/pulls?sort=created&state=open")
+      stub_request(:get, pull_requests_url)
         .to_return(status: 200, body: [pull_request_api_response, pull_request_api_response].to_json, headers: { "Content-Type": "application/json" })
 
       repo = Repo.new(repo_name)
@@ -159,7 +160,7 @@ RSpec.describe Repo do
         .to_return(status: 200, body: arbitrary_config.to_json, headers: { "Content-Type": "application/json" })
       non_dependabot_response = pull_request_api_response({ user: { login: "foo" } })
 
-      stub_request(:get, "https://api.github.com/repos/alphagov/#{repo_name}/pulls?sort=created&state=open")
+      stub_request(:get, pull_requests_url)
         .to_return(status: 200, body: [non_dependabot_response, pull_request_api_response].to_json, headers: { "Content-Type": "application/json" })
 
       repo = Repo.new(repo_name)


### PR DESCRIPTION
`Repo.dependabot_pull_requests` was supposed to be fetching all pull requests matching some criteria, but because the Octokit library wasn't handling pagination for it, it was in fact only fetching the first page.

Enabling automatic pagination in the library saves us having to handle pagination ourselves, and saves us writing complicated tests of the behaviour in our own code.