### PR TITLE
Remove "This rubygem could not be found." message from log output

### DIFF
--- a/lib/change_set.rb
+++ b/lib/change_set.rb
@@ -4,7 +4,6 @@ Dependency = Struct.new(:name) do
       .then { |response| YAML.safe_load response }
       .any? { |owner| owner["handle"] == "govuk" }
   rescue NoMethodError
-    puts "This rubygem could not be found."
     false
   end
 end


### PR DESCRIPTION
It was filling up the logs and providing no value