### PR TITLE
Make govuk-dependabot-merger resilient to missing config

### DIFF
--- a/lib/policy_manager.rb
+++ b/lib/policy_manager.rb
@@ -44,7 +44,7 @@ class PolicyManager
   def auto_merge_external?(dependency_name, auto_merge_setting, update_external_dependencies)
     if update_external_dependencies
       if auto_merge_setting && !dependabot_cooldown_days_acceptable?
-        puts "blocking auto merging of #{dependency_name} because the configured dependabot cooldown is too low (#{@dependabot_cooldown_days})"
+        puts "blocking auto merging of #{dependency_name} because the configured dependabot cooldown is too low or is misconfigured (#{@dependabot_cooldown_days})"
         false
       else
         auto_merge_setting
@@ -71,7 +71,7 @@ class PolicyManager
   end
 
   def dependabot_cooldown_days_acceptable?
-    @dependabot_cooldown_days >= 3
+    @dependabot_cooldown_days.is_a?(Integer) && @dependabot_cooldown_days >= 3
   end
 
   def reasons_not_to_merge(pull_request)

--- a/spec/lib/policy_manager_spec.rb
+++ b/spec/lib/policy_manager_spec.rb
@@ -27,6 +27,23 @@ RSpec.describe PolicyManager do
     end
   end
 
+  describe "#dependabot_cooldown_days_acceptable?" do
+    it "returns true if dependabot_cooldown_days is >= 3" do
+      policy_manager = PolicyManager.new({}, 5)
+      expect(policy_manager.dependabot_cooldown_days_acceptable?).to eq(true)
+    end
+
+    it "returns false if dependabot_cooldown_days is < 3" do
+      policy_manager = PolicyManager.new({}, 2)
+      expect(policy_manager.dependabot_cooldown_days_acceptable?).to eq(false)
+    end
+
+    it "returns false if dependabot_cooldown_days is not an integer" do
+      policy_manager = PolicyManager.new({}, "not an integer")
+      expect(policy_manager.dependabot_cooldown_days_acceptable?).to eq(false)
+    end
+  end
+
   describe "#dependency_policy" do
     RSpec.shared_examples "doesn't allow auto-merging internal dependencies" do
       let(:expected_policy) { { auto_merge: false, allowed_semver_bumps: [] } }


### PR DESCRIPTION
At time of writing, govuk-replatform-test-app lacks a `.github/dependabot.yml` file. This causes the dependabot_cooldown_days method to return the hash `{ "error" => "404" }`.

That was tripping up the `dependabot_cooldown_days_acceptable?` method, which does a comparison and expects an Integer. That was causing [workflow failures](https://github.com/alphagov/govuk-dependabot-merger/actions/runs/30896366036/job/91950105661) and any repos below govuk-replatform-test-app in the list of repos was not being evaluated.